### PR TITLE
allow posting with default index and/or type for bulk requests

### DIFF
--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -80,7 +80,11 @@
 
 (defn bulk-url
   ([]
-     (url-with-path "_bulk")))
+     (url-with-path "_bulk"))
+  ([index-name]
+     (url-with-path index-name "_bulk"))
+  ([index-name mapping-type]
+     (url-with-path index-name mapping-type "_bulk")))
 
 (defn count-url
   ([]

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -104,16 +104,29 @@
     (rest/get (rest/scroll-url)
                :query-params qp)))
 
-(defn bulk
-  "Performs a bulk operation"
-  [operations & {:as params}]
+(defn ^:private bulk-with-url
+  [url operations & {:as params}]
   (let [bulk-json (map json/encode operations)
         bulk-json (-> bulk-json
                       (interleave (repeat "\n"))
                       (string/join))]
-    (rest/post-string (rest/bulk-url)
+    (rest/post-string url
                       :body bulk-json
                       :query-params params)))
+(defn bulk
+  "Performs a bulk operation"
+  [operations & params]
+  (apply bulk-with-url (rest/bulk-url) operations params))
+
+(defn bulk-with-index
+  "Performs a bulk operation defaulting to the index specified"
+  [index operations & params]
+  (apply bulk-with-url (rest/bulk-url index) operations params))
+
+(defn bulk-with-index-and-type
+  "Performs a bulk operation defaulting to the index and type specified"
+  [index mapping-type operations & params]
+  (apply bulk-with-url (rest/bulk-url index mapping-type) operations params))
 
 (defn replace
   "Replaces document with given id with a new one"

--- a/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
@@ -19,36 +19,29 @@
 (def ^{:const true} index-type "person")
 
 (defn index-operation
-  [index mapping-type {id :_id} ]
-  {"index"  {"_index" index
-                      "_type"  mapping-type
-                      "_id"    id}})
+  [doc]
+  {"index"
+   (select-keys doc [:_index :_type :_id])})
 
 (defn delete-operation
-  [index mapping-type id ]
-  {"delete"  {"_index" index
-                      "_type"  mapping-type
-                      "_id"    id}})
+  [doc]
+  {"delete"  (select-keys doc [:_index :_type :_id])})
 
 (defn bulk-index
-  "generates the content for a bulk operation
-   currently :index and :delete are supported"
-  ([index mapping-type documents]
-     (let [operations (map (partial index-operation index mapping-type)
-                           documents)]
+  "generates the content for a bulk insert operation"
+  ([documents]
+     (let [operations (map index-operation documents)]
        (interleave operations documents))))
 
 (defn bulk-delete
-  "generates the content for a bulk operation
-   currently :index and :delete are supported"
-  ([index mapping-type documents]
-     (let [operations (map (partial delete-operation index mapping-type) documents)]
+  "generates the content for a bulk delete operation"
+  ([documents]
+     (let [operations (map delete-operation documents)]
        operations)))
 
-
 (deftest ^{:indexing true} test-bulk-insert
-  (let [document          fx/person-jack
-        insert-operations (bulk-index index-name index-type (repeat 10 document))
+  (let [document          (assoc fx/person-jack :_index index-name :_type index-type)
+        insert-operations (bulk-index (repeat 10 document))
         response          (doc/bulk insert-operations :refresh true)
         first-id          (-> response :items first :create :_id)
         get-result        (doc/get index-name index-type first-id)]
@@ -63,14 +56,48 @@
          first-id   :_id
          true       :exists)))
 
+(deftest ^{:indexing true} test-bulk-with-index
+  (let [document          (assoc fx/person-jack :_type index-type)
+        insert-operations (bulk-index (repeat 10 document))
+        response          (doc/bulk-with-index index-name insert-operations :refresh true)
+        first-id          (-> response :items first :create :_id)
+        get-result        (doc/get index-name index-type first-id)]
+    (is (every? ok? (->> response :items (map :create))))
+
+    (is (= 10 (:count (doc/count index-name index-type))))
+    (is (idx/exists? index-name))
+    (are [expected actual] (= expected (actual get-result))
+         document   :_source
+         index-name :_index
+         index-type :_type
+         first-id   :_id
+         true       :exists)))
+
+(deftest ^{:indexing true} test-bulk-with-index-and-type
+  (let [document          fx/person-jack
+        insert-operations (bulk-index (repeat 10 document))
+        response          (doc/bulk-with-index-and-type index-name index-type insert-operations :refresh true)
+        first-id          (-> response :items first :create :_id)
+        get-result        (doc/get index-name index-type first-id)]
+    (is (every? ok? (->> response :items (map :create))))
+
+    (is (= 10 (:count (doc/count index-name index-type))))
+    (is (idx/exists? index-name))
+    (are [expected actual] (= expected (actual get-result))
+         document   :_source
+         index-name :_index
+         index-type :_type
+         first-id   :_id
+         true       :exists)))
+
 (deftest ^{:indexing true} test-bulk-delete
-  (let [document        fx/person-jack
-        response        (doc/bulk (bulk-index index-name index-type (repeat 10 document)) :refresh true)
+  (let [insert-ops      (bulk-index (repeat 10 fx/person-jack))
+        response        (doc/bulk-with-index-and-type index-name index-type insert-ops :refresh true)
         docs            (->> response :items (map :create) )
         initial-count   (:count (doc/count index-name index-type))
-        delete-response (doc/bulk (bulk-delete index-name index-type  (map :_id docs)) :refresh true)]
+        delete-response (doc/bulk-with-index-and-type index-name index-type (bulk-delete docs) :refresh true)]
     (is (every? ok? (->> response :items (map :create))))
     (is (= 10 initial-count))
 
-    (is (every? ok? (->> response :items (map :create))))
+    (is (every? ok? (->> delete-response :items (map :delete))))
     (is (= 0 (:count (doc/count index-name index-type))))))


### PR DESCRIPTION
Add methods to post bulk requests with a default index/mapping type.
It looks like in the rest of elastisch you've mainly got separate methods for these rather than optional parameters, so I've done the same.
It might be worth pulling out the bulk-delete and bulk-index methods from the test to make it a bit easier on clients building these requests - is there a sensible namespace to put them in?
