### PR TITLE
start an embedded ES node for tests

### DIFF
--- a/test/clojurewerkz/elastisch/test/helpers.clj
+++ b/test/clojurewerkz/elastisch/test/helpers.clj
@@ -1,27 +1,48 @@
 (ns clojurewerkz.elastisch.test.helpers
-  (:require [clojurewerkz.elastisch.native :as es]))
-
-(defn ci?
-  "Returns true if tests are running in the CI environment
-   (on travis-ci.org)"
-  []
-  (System/getenv "CI"))
+  (:require [clojurewerkz.elastisch.native :as es])
+  (:import  [org.elasticsearch.node NodeBuilder]
+            [org.elasticsearch.common.settings ImmutableSettings]))
 
 (defn infer-cluster-name
   "Returns current cluster name set via the ES_CLUSTER_NAME env variable"
   []
   (get (System/getenv) "ES_CLUSTER_NAME" "elasticsearch_antares"))
 
+(def ^{:dynamic true}
+  *local-node*)
+
+(defn start-local-node []
+  "Start an embedded data node for the tests"
+  (let [tcp-port     9301
+        our-settings (.. ImmutableSettings
+                         settingsBuilder
+                         (put "gateway.type" "none")
+                         (put "transport.tcp.port" tcp-port)
+                         (put "multicast.enabled" false)
+                         build)
+        node (.. NodeBuilder
+                 nodeBuilder
+                 (settings our-settings)
+                 (clusterName (infer-cluster-name))
+                 build)]
+    (. node start)
+    (alter-var-root (var *local-node*) (constantly node))
+    node))
+
 (defn connect-native-client
   ([]
      (connect-native-client (infer-cluster-name)))
   ([cluster-name]
-     (es/connect! [["127.0.0.1" 9300]]
+     (es/connect! [["127.0.0.1" 9301]]
                   {"cluster.name" cluster-name })))
 
 (defn maybe-connect-native-client
   []
-  (if (not (ci?))
-    (when (not (es/connected?))
-      (connect-native-client))
-    (println "ES_CLUSTER_NAME env variable is not set. Please set it to your local ES cluster name.")))
+  (when (not (bound? (var *local-node*)))
+    (start-local-node)
+    ;; TODO - use client straight off the node?
+    ;; (. node client)
+    )
+  (when (not (es/connected?))
+    (connect-native-client))
+  (println "ES_CLUSTER_NAME env variable is not set. Please set it to your local ES cluster name."))


### PR DESCRIPTION
This should mean the native tests can run on CI again.
Currently the embedded node is always started, and port is hardcoded to avoid conflicting with a running external node. 
I've left the connection going through the existing connect code, but it would be possible to call (. node connect) to get a local connection instead.
This change also means that the tests will always run against the version of ES specified in the project.clj  - the native clients aren't compatible across major version changes, so this makes sense, but should probably be documented somewhere.
