### PR TITLE
Add Custom Boost Factor query type helper.

### DIFF
--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -60,6 +60,14 @@
   [& {:as options}]
   {:custom_score options})
 
+(defn custom-boost-factor
+  "Custom Boost Factor
+
+  For more information, please refer to http://www.elasticsearch.org/guide/reference/query-dsl/custom-boost-factor-query/"
+  [factor query]
+  {:custom_boost_factor {:query query
+                         :boost_factor factor}})
+
 (defn constant-score
   "Constant Score Query
 

--- a/test/clojurewerkz/elastisch/query_test.clj
+++ b/test/clojurewerkz/elastisch/query_test.clj
@@ -78,6 +78,16 @@
          params   (:params custom-score)
          script   (:script custom-score))))
 
+(deftest custom-boosting-factor
+  (let [query {:term {:foo [:bar :baz]}}
+        factor 3.4
+        result (query/custom-boost-factor factor query)
+        custom-boost-factor (:custom_boost_factor result)]
+
+    (are [expected actual] (= expected actual)
+         query  (:query  custom-boost-factor)
+         factor (:boost_factor custom-boost-factor))))
+
 (deftest constant-score-query-test
   (let [query   {:terms {:foo [:bar :baz]}}
         boost   2.0


### PR DESCRIPTION
This branch adds and tests the custom boost factor query helper.

http://www.elasticsearch.org/guide/reference/query-dsl/custom-boost-factor-query/
