### PR TITLE
Properly get fields into native search response

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -238,8 +238,8 @@
   [fields]
   (cond
    (instance? java.util.Map fields) (into {} (map (fn [^java.util.Map$Entry e]
-                                                        [(keyword (.getKey e))
-                                                         (.. e getValue getValue)]) fields))
+                                                    [(keyword (.getKey e))
+                                                     (.. e getValue getValue)]) fields))
    :else fields))
 
 (defn ^IPersistentMap get-response->map
@@ -516,13 +516,16 @@
 
 (defn- ^IPersistentMap search-hit->map
   [^SearchHit sh]
-  {:_index    (.getIndex sh)
-   :_type     (.getType sh)
-   :_id       (.getId sh)
-   :_score    (.getScore sh)
-   :_version  (.getVersion sh)
-   :_source   (convert-source-result (.getSource sh))
-   :_fields   (convert-fields-result (.getFields sh))})
+  (let [source (.getSource sh)
+        source-or-fields (if source
+                           {:_source (convert-source-result source)}
+                           {:_fields (convert-fields-result (.getFields sh))})]
+    (clojure.core/merge source-or-fields
+                        {:_index    (.getIndex sh)
+                         :_type     (.getType sh)
+                         :_id       (.getId sh)
+                         :_score    (.getScore sh)
+                         :_version  (.getVersion sh)})))
 
 (defn- search-hits->seq
   [^SearchHits hits]


### PR DESCRIPTION
When returning a subset of fields from a query, _source was returned as nil and the :_fields key was missing. For example:

``` clojure
(let [res (esd/search "index" "mapping"
                        :query (q/term :my_term "foo")
                        :fields ["field1" "field2"]
                        :size 5)]
    (pp/pprint (esrsp/hits-from res))))
```

The PR will return either :_source if no filtering fields are specified, or :_fields if any are.
