### PR TITLE
Do not perform a bulk operation if its list of operations is empty

### DIFF
--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -19,7 +19,8 @@
 (defn bulk
   "Performs a bulk operation"
   [operations & params]
-  (apply bulk-with-url (rest/bulk-url) operations params))
+  (when (not-empty operations)
+    (apply bulk-with-url (rest/bulk-url) operations params)))
 
 (defn bulk-with-index
   "Performs a bulk operation defaulting to the index specified"


### PR DESCRIPTION
If you try to perform a bulk operation with an empty list, ElasticSearch will return an error 400:

```
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
Content-Length: 86

{"error":"Failed to derive xcontent from org.elasticsearch.common.bytes.BytesArray@0"}
```

Here is a sample project which shows that:

`project.clj`:

``` clj
(defproject foo "0.1.0-SNAPSHOT"
  :description "FIXME: write description"
  :url "http://example.com/FIXME"
  :license {:name "Eclipse Public License"
            :url "http://www.eclipse.org/legal/epl-v10.html"}
  :main foo.core
  :dependencies [[org.clojure/clojure "1.5.1"]
                 [clojurewerkz/elastisch "1.1.1"]])
```

`src/foo/core.clj`:

``` clj
(ns foo.core
 (:require [clojurewerkz.elastisch.rest      :as esr]
           [clojurewerkz.elastisch.rest.bulk :as esb]))

(defn -main
  []
  (esr/connect! "http://localhost:9200")
  (esb/bulk (esb/bulk-index [])))
```

If you try a `lein run`, here is what you’ll get:

```
Exception in thread "main" clojure.lang.ExceptionInfo:
  clj-http: status 400 {:object {:trace-redirects ["http://localhost:9200/_bulk"],
    :request-time 5, :status 400,
    :headers {"content-type" "application/json; charset=UTF-8", "content-length" "86"},
    :body "{\"error\":\"Failed to derive xcontent from org.elasticsearch.common.bytes.BytesArray@0\"}"},
    […]}
    at clj_http.client$wrap_exceptions$fn__1603.invoke(client.clj:133)
    […]
    at clojurewerkz.elastisch.rest$post_string.doInvoke(rest.clj:21)
    at clojure.lang.RestFn.invoke(RestFn.java:486)
    at clojurewerkz.elastisch.rest.bulk$bulk_with_url.doInvoke(bulk.clj:16)
    […]
```

This pull request prevents that by avoiding to send a bulk request to ES if its list of operations is empty.
