### PR TITLE
Upgrade to cheshire 5.2.0 and removal of cheshire.custom as it's deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc/*
 deploy.docs.sh
 .lein-*
 data/*
+target

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :description "Minimalistic fully featured well documented Clojure ElasticSearch client"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure   "1.5.1"]
-                 [cheshire              "5.1.1"]
-                 [clj-http              "0.7.2" :exclusions [org.clojure/clojure]]
-                 [clojurewerkz/support  "0.16.0"]
+                 [cheshire              "5.2.0"]
+                 [clj-http              "0.7.6" :exclusions [org.clojure/clojure]]
+                 [clojurewerkz/support  "0.17.0-SNAPSHOT"]
                  ;; used by the native client
                  [org.elasticsearch/elasticsearch "0.90.3"]]
   :min-lein-version "2.0.0"

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -1,7 +1,7 @@
 (ns clojurewerkz.elastisch.rest
   (:refer-clojure :exclude [get])
   (:require [clj-http.client :as http]
-            [cheshire.custom :as json])
+            [cheshire.core :as json])
   (:use [clojure.string :only [join]])
   (:import java.net.URLEncoder))
 


### PR DESCRIPTION
Since cheshire.custom has been deprected in favour of cheshire.json and cheshire.generate (http://dakrone.github.io/cheshire/cheshire.custom.html), I updated cheshire in this library, as well as cloureworkz.support and upgrade clj-http to a version that supported cheshire 5.2.0

All the rest tests look to pass for me.

Related to:
https://github.com/clojurewerkz/support/pull/1
