### PR TITLE
Tests on Travis fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: clojure
 lein: lein2
 services:
   - elasticsearch
+env:
+  - ES_CLUSTER_NAME=elasticsearch
 before_install:
   - sudo service elasticsearch status
 script: lein2 all test :ci

--- a/test/clojurewerkz/elastisch/test/helpers.clj
+++ b/test/clojurewerkz/elastisch/test/helpers.clj
@@ -21,7 +21,5 @@
 
 (defn maybe-connect-native-client
   []
-  (if (not (ci?))
-    (when (not (es/connected?))
-      (connect-native-client))
-    (println "ES_CLUSTER_NAME env variable is not set. Please set it to your local ES cluster name.")))
+  (when (not (es/connected?))
+    (connect-native-client)))


### PR DESCRIPTION
On Travis, [tests](https://travis-ci.org/clojurewerkz/elastisch/jobs/10863208) fail due to the `ES_CLUSTER_NAME` env var which is not set. They still don’t pass (there’s a `java.lang.IllegalArgumentException: Unable to resolve classname: double, compiling:(clojurewerkz/elastisch/native/conversion.clj:507)` with `dev,1.3` profile), but that’s a “normal failure”, i.e. due to the code, not a problem in the test suite.
