### PR TITLE
Support for _parent & _routing in bulk index/delete operations

### DIFF
--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -32,14 +32,16 @@
   [index mapping-type operations & params]
   (apply bulk-with-url (rest/bulk-url index mapping-type) operations params))
 
+(def ^:private special-operation-keys
+  [:_index :_type :_id :_routing :_percolate :_parent :_timestamp :_ttl])
+
 (defn index-operation
   [doc]
-  {"index"
-   (select-keys doc [:_index :_type :_id])})
+  {"index" (select-keys doc special-operation-keys)})
 
 (defn delete-operation
   [doc]
-  {"delete"  (select-keys doc [:_index :_type :_id])})
+  {"delete" (select-keys doc special-operation-keys)})
 
 (defn bulk-index
   "generates the content for a bulk insert operation"


### PR DESCRIPTION
This adds support for the following special keys for bulk index/delete operations: `_routing`, `_percolate`, `_parent`, `_timestamp`, and `_ttl`, in addition of `_index`, `_type` and `_id` that are already supported. I needed `_routing` and `_parent` to migrate an index with parent/child relationships, and I added a few more in this PR.
