### PR TITLE
added total field to date histogram

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -613,7 +613,7 @@
     {:_type   DateHistogramFacet/TYPE
      :entries (map (fn [^DateHistogramFacet$Entry et]
                      {:time (.getTime et) :count (.getCount et) :total_count (.getTotalCount et)
-                      :mean (.getMean et) :min (.getMin et) :max (.getMax et)})
+                      :mean (.getMean et) :min (.getMin et) :max (.getMax et) :total (.getTotal et)})
                    (.getEntries ft))})
 
   ;; {:comments {:total 68.0,


### PR DESCRIPTION
Date histogram queries using the native client were missing the 'total' field in the output.
