### PR TITLE
Added seq-like API for scroll queries

### DIFF
--- a/src/clojurewerkz/elastisch/native/document.clj
+++ b/src/clojurewerkz/elastisch/native/document.clj
@@ -316,7 +316,7 @@
         scroll-id (:_scroll_id prev-resp)]
     (if (seq hits)
       (concat hits (lazy-seq (scroll-seq (scroll scroll-id :scroll "1m"))))
-      (concat hits '()))))
+      hits)))
 
 (defn replace
   "Replaces document with given id with a new one"

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -176,7 +176,7 @@
         scroll-id (:_scroll_id prev-resp)]
     (if (seq hits)
       (concat hits (lazy-seq (scroll-seq (scroll scroll-id :scroll "1m"))))
-      (concat hits '()))))
+      hits)))
 
 (defn replace
   "Replaces document with given id with a new one"

--- a/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
@@ -94,5 +94,4 @@
                                    :scroll "1m"
                                    :size 2))]
     (is (= 0 (count res-seq)))
-    (is (= true (realized? res-seq)))
-    (is (= true (seq? res-seq)))))
+    (is (= true (coll? res-seq)))))

--- a/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
@@ -92,5 +92,4 @@
                                    :scroll "1m"
                                    :size 2))]
     (is (= 0 (count res-seq)))
-    (is (= true (realized? res-seq)))
-    (is (= true (seq? res-seq)))))
+    (is (= true (coll? res-seq)))))


### PR DESCRIPTION
This is a very early version of it, _please_ don't merge it right away (I bet you won't do that anyway, though.)

Here are problems I see:
1. `scroll-each` shouldn't be in native/document, since it almost doesn't care about API details (however, it needs appropriate doc/scroll)
2. Naming is odd.
3. It doesn't respect scroll time passed to the initializing search.
4. I have no idea how to use function composition and other fancy functional programming techniques.

Would love to hear any thoughts on how to make this better.

Thanks!
