### PR TITLE
For sorting with the native client, allow the use of SortBuilders.

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -18,7 +18,7 @@
            [org.elasticsearch.action.count CountRequest CountResponse]
            [org.elasticsearch.action.search SearchRequest SearchResponse SearchScrollRequest]
            [org.elasticsearch.search.builder SearchSourceBuilder]
-           org.elasticsearch.search.sort.SortOrder
+           [org.elasticsearch.search.sort SortBuilder SortOrder]
            [org.elasticsearch.search SearchHits SearchHit]
            [org.elasticsearch.search.facet Facets Facet]
            [org.elasticsearch.search.facet.terms TermsFacet TermsFacet$Entry]


### PR DESCRIPTION
Modify elastisch.native.conversion/set-sort to accept a SortBuilder for its "sort" argument.

For example, we pass in a GeoDistanceSortBuilder, which we make like this:

``` clojure
(ns some-module
  "Example of making a GeoDistanceSortBuilder."
  (:import [org.elasticsearch.search.sort GeoDistanceSortBuilder SortOrder]
           [org.elasticsearch.common.unit DistanceUnit]))

(defn mk-geo-distance-sort-builder
  "Inputs:
     * a {:lat, :lon} hashmap
     * sort-order keyword (either :asc or :desc)
   Create a GeoDistanceSortBuilder."
  [coords order]
  (let [o  (if (= order :asc) SortOrder/ASC SortOrder/DESC)
        sb (GeoDistanceSortBuilder. "latitude_longitude")] 
    (doto sb
      (.point (:lat coords) (:lon coords))
      (.order o)
      (.unit DistanceUnit/MILES))
    sb))
```

If you find that code useful, please feel free to make use of it as well.
