### PR TITLE
remove attempts to call missing method `isFound` on `UpdateResponse`

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -400,7 +400,6 @@
   ;; matches REST API responses
   ;; example: {:ok true, :_index people, :_type person, :_id 1, :_version 2}
   {:_index (.getIndex r) :type (.getType r) :_id (.getId r)
-   :found (.isFound r) :found? (.isFound r)
    :get-result (when-let [gr (.getGetResult r)]
                  (get-result->map gr))})
 


### PR DESCRIPTION
This was only introduced in a recent commit,

https://github.com/clojurewerkz/elastisch/commit/91142d1e496b5d91da6b6c10e5e897f513ad6980
