### PR TITLE
Fixing "remove aliases" in native client

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -498,7 +498,7 @@
 
 (defn ^SearchSourceBuilder ^:private set-sort
   [^SearchSourceBuilder sb sort]
-  (cond 
+  (cond
    (instance? String sort)       (.sort sb ^String sort)
    ;; Allow 'sort' to be a SortBuilder, such as a GeoDistanceSortBuilder.
    (instance? SortBuilder sort)  (.sort sb ^SortBuilder sort)
@@ -1188,7 +1188,7 @@
   req)
 
 (defn- apply-remove-alias
-  [^IndicesAliasesRequest req {:keys {index aliases}}]
+  [^IndicesAliasesRequest req {:keys [index aliases]}]
   (.removeAlias req ^String index (->string-array aliases))
   req)
 

--- a/src/clojurewerkz/elastisch/native/index.clj
+++ b/src/clojurewerkz/elastisch/native/index.clj
@@ -227,10 +227,11 @@
            (cnv/indices-segments-response->map res))))
 
 (defn update-aliases
-  "Performs a batch of alias operations. Takes a collection of actions in the form of
+  "Performs a batch of alias operations. Takes a collection of actions in the following form where
+   plural keys (indices, aliases) can be supplied as collections or single strings
 
-   { :add    { :index \"test1\" :alias \"alias1\" } }
-   { :remove { :index \"test1\" :alias \"alias1\" } }"
+  [{:add    { :indices \"test1\" :alias \"alias1\" }}
+   {:remove { :index \"test1\" :aliases \"alias1\" }}]"
   [^Client conn ops & args]
   (let [opts                        (ar/->opts args)
         ft                          (es/admin-update-aliases conn (cnv/->indices-aliases-request ops opts))

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -107,6 +107,11 @@
   (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices ["aliased-index"]}}
                                                {:add {:alias "alias2" :indices ["aliased-index"]}}]))))
 
+(deftest ^{:indexing true :native true} test-create-an-index-with-an-alias-and-delete-it
+  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+  (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))
+  (is (acknowledged? (idx/update-aliases conn [{:remove {:aliases "alias1" :index "aliased-index"}}]))))
+
 (deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
   (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
     (is (acknowledged? response))))


### PR DESCRIPTION
Hi,
The "remove aliases" functionality does not work with the native client as described in the documentation. This is mainly due to the incorrect destructuring being used in apply-remove-alias but the differently named keys (index vs indices, alias vs aliases) in the documentation was also very confusing.

I've fixed the destructuring, updated the documentation to give a working example and added a test.

Thanks!
