### PR TITLE
add seperate function for terms query so it shows up in API docs

### DIFF
--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -23,6 +23,13 @@
   (merge { (if (coll? values) :terms :term) (hash-map key values) }
          (ar/->opts args)))
 
+(defn terms
+  "Terms Query
+
+  For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html"
+  [key values & args]
+  (apply term key values args))
+
 (defn range
   "Range Query
 

--- a/test/clojurewerkz/elastisch/query_test.clj
+++ b/test/clojurewerkz/elastisch/query_test.clj
@@ -17,11 +17,12 @@
   (let [expected {:term {:foo "bar"}}]
     (is (= expected (query/term :foo "bar"))))
 
-  (let [expected {:terms {:foo [:bar :baz]}}]
-    (is (= expected (query/term :foo [:bar :baz]))))
-
   (let [expected {:term {:foo :bar} :minimum_match 2}]
     (is (= expected (query/term :foo :bar :minimum_match 2)))))
+
+(deftest terms-query-test
+  (let [expected {:terms {:foo [:bar :baz]}}]
+    (is (= expected (query/term :foo [:bar :baz])))))
 
 (deftest range-query-test
   (is (= {:range {:foo {:gt 5 :lt 10 :include_upper false :include_lower false}}}


### PR DESCRIPTION
As discussed in #96 this adds a separate function for Elasticsearch's `terms query` so other people don't falsely assume it's not implemented in Elastisch. It has been implemented for some time but under the umbrella of the `term query` which can lead to confusion.  
