### PR TITLE
Simplify code.

### DIFF
--- a/src/clojurewerkz/elastisch/rest/multi.clj
+++ b/src/clojurewerkz/elastisch/rest/multi.clj
@@ -18,9 +18,8 @@
   [conn url queries & args]
   (let [opts         (ar/->opts args)
         msearch-json (map json/encode queries)
-        msearch-json (-> msearch-json
-                         (interleave (repeat "\n"))
-                         (string/join))]
+        msearch-json (->> msearch-json
+                          (string/join "\n"))]
     (rest/get conn url
               {:body msearch-json
                :query-params opts})))


### PR DESCRIPTION
Eschews interleave and join in favour of join with separator.
