### PR TITLE
Aggregation Data in SingleBucketAggregation

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -986,7 +986,9 @@
   ;; Missing, Global, etc
   SingleBucketAggregation
   (aggregation-value [^SingleBucketAggregation agg]
-    {:doc_count (.getDocCount agg)})
+    (->> (.getAggregations agg)
+         (aggregations-to-map)
+         (clojure.core/merge {:doc_count (.getDocCount agg)})))
 
   Stats
   (aggregation-value [^Stats agg]


### PR DESCRIPTION
Currently, SingleBucketAggregation results only produce the `:doc_count` but they may also contain child aggregations which should not be dropped.
