### PR TITLE
Remove all special operation keys from bulk documents

### DIFF
--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -59,7 +59,7 @@
   "generates the content for a bulk insert operation"
   ([documents]
      (let [operations (map index-operation documents)
-           documents  (map #(dissoc % :_index :_type) documents)]
+           documents  (map #(apply dissoc % special-operation-keys) documents)]
        (interleave operations documents))))
 
 (defn bulk-delete

--- a/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
@@ -37,7 +37,10 @@
 (let [conn (rest/connect)]
   (deftest ^{:rest true :indexing true} test-bulk-insert
     (let [document          fx/person-jack
-          for-index         (assoc document :_index index-name :_type index-type)
+          for-index         (assoc document
+                                   :_index index-name
+                                   :_type index-type
+                                   :_routing "routing-key")
           insert-operations (bulk/bulk-index (repeat 10 for-index))
           response          (bulk/bulk conn insert-operations :refresh true)
           first-id          (-> response :items first :create :_id)


### PR DESCRIPTION
Intended to fix #116 
