### PR TITLE
Add ability to retry on conflict during upsert, both bulk and regular

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -425,12 +425,14 @@
        (.script r script)
        (.scriptParams r ^Map params)
        r))
-  ([index-name mapping-type ^String id ^String script ^Map params {:keys [script routing refresh fields parent]}]
+  ([index-name mapping-type ^String id ^String script ^Map params {:keys [script routing refresh retry-on-conflict fields parent]}]
      (let [r (UpdateRequest. index-name mapping-type id)]
        (.script r script)
        (.scriptParams r ^Map params)
        (when refresh
          (.refresh r))
+       (when retry-on-conflict
+         (.retryOnConflict r retry-on-conflict))
        (when routing
          (.routing r routing))
        (when parent
@@ -440,13 +442,15 @@
        r)))
 
 (defn ^UpdateRequest ->upsert-request
-  ([index-name mapping-type ^String id ^Map doc {:keys [script routing refresh fields parent]}]
+  ([index-name mapping-type ^String id ^Map doc {:keys [script routing refresh retry-on-conflict fields parent]}]
      (let [doc (wlk/stringify-keys doc)
            r   (UpdateRequest. index-name mapping-type id)]
        (.doc r ^Map doc)
        (.upsert r ^Map doc)
        (when refresh
          (.refresh r))
+       (when retry-on-conflict
+         (.retryOnConflict r retry-on-conflict))
        (when routing
          (.routing r routing))
        (when parent

--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -45,7 +45,7 @@
                                            index mapping-type) operations params))
 
 (def ^:private special-operation-keys
-  [:_index :_type :_id :_routing :_percolate :_parent :_timestamp :_ttl])
+  [:_index :_type :_id :_retry_on_conflict :_routing :_percolate :_parent :_timestamp :_ttl])
 
 (defn index-operation
   [doc]


### PR DESCRIPTION
If there are simultaneous updates to a single document, Elasticsearch has the potential to raise either `VersionConflictEngineException` or `DocumentAlreadyExistsException`. This pull request exposes the retry flag that instructs ES to automatically catch and retry updates that raise either exception.
