### PR TITLE
Optional params implementation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,9 +38,10 @@
                    :snapshots   :snapshots
                    :native      :native
                    :rest        :rest
+                   :version-dependent :version-dependent
                    :all         (constantly true)
                    :default     (constantly true)
-                   :ci          (fn [m] (not (:native m)))}
+                   :ci          (fn [m] (and (not (:native m)) (not (:version-dependent m))))}
   :mailing-list {:name "clojure-elasticsearch"
                  :archive "https://groups.google.com/group/clojure-elasticsearch"
                  :post "clojure-elasticsearch@googlegroups.com"})

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -77,7 +77,15 @@
 
 
 (defn update-with-script
-  "Updates a document using a script"
+  "Updates a document using a script.
+
+  Examples:
+
+  (require '[clojurewerkz.elastisch.rest.document :as doc])
+
+  (doc/update-with-script conn \"people\" \"person\" \"1825c5432775b8d1a477acfae57e91ac8c767aed\"
+                                  \"ctx._source.age = ctx._source.age += 1\" {} :lang \"groovy\")
+  "
   ([^Connection conn index mapping-type id script]
      (rest/post conn (rest/record-update-url conn
                                              index mapping-type id)
@@ -85,7 +93,12 @@
   ([^Connection conn index mapping-type id script params]
      (rest/post conn (rest/record-update-url conn
                                              index mapping-type id)
-                {:body {:script script :params params}})))
+                {:body {:script script :params params}}))
+  ([^Connection conn index mapping-type id script params & args]
+     (rest/post conn (rest/record-update-url conn
+                                             index mapping-type id)
+                (let [optional-params (ar/->opts args)]
+                  {:body (merge {:script script :params params} optional-params)}))))
 
 (defn get
   "Fetches and returns a document by id or nil if it does not exist.
@@ -306,7 +319,7 @@
             {:body (json/encode {:query query}) :query-params (ar/->opts args)}))
 
 
-(defn analyze 
+(defn analyze
   "Examples:
 
    (require '[clojurewerkz.elastisch.rest.document :as doc])


### PR DESCRIPTION
This should fix Issue #122 

I've added new update-with-script version to maintain backward compatibility. There are three tests two to prove the backward compatibility and one to add the optional params.

The tests are elasticsearch version dependent. I've run them with success on elasticsearch-1.1.0 with `lang-groovy`, but I had to comment first two to run them in elasticsearch-1.3.2. In order not to break CI I've added new profile `:version-dependent` to exclude the tests from CI (we do not control es versions and plugins).

The reason why the default two versions do not work on 1.2+ is that elasticsearch disabled scrip execution by default, except _sandboxed_ scripts. Groovy is considered sandboxed, but mvel not. Groovy does not need a plugin on 1.3+ since its included in the es core.

Please let me know if it makes sense.
