### PR TITLE
Silence warning for replacing `update`

### DIFF
--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -8,7 +8,7 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.elastisch.native
-  (:refer-clojure :exclude [get count])
+  (:refer-clojure :exclude [get count update])
   (:require [clojurewerkz.elastisch.native.conversion :as cnv])
   (:import org.elasticsearch.client.Client
            org.elasticsearch.client.transport.TransportClient


### PR DESCRIPTION
WARNING: update already refers to: #'clojure.core/update in namespace: clojurewerkz.elastisch.native, being replaced by: #'clojurewerkz.elastisch.native/update
