### PR TITLE
Fix a few incorrect tests found with Eastwood lint tool

### DIFF
--- a/test/clojurewerkz/elastisch/rest_api/facets_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/facets_test.clj
@@ -57,7 +57,7 @@
                                                                      {:to 45}]}}}})
           facets       (facets-from result)]
       (is (>= (-> facets :ages :ranges second :count) 1))
-      (is (>= (-> facets :ages :ranges last :count))) 4))
+      (is (>= (-> facets :ages :ranges last :count) 4))))
 
   (deftest ^{:facets true :rest true} test-range-facet-over-age-2
     (let [index-name   "people"
@@ -69,7 +69,7 @@
           facets       (facets-from result)]
       (is (>= (-> facets :ages :entries first :count) 1))
       (is (>= (-> facets :ages :entries second :count) 2))
-      (is (>= (-> facets :ages :entries last :count))) 1))
+      (is (>= (-> facets :ages :entries last :count) 1))))
 
   (deftest ^{:facets true :rest true} test-date-histogram-facet-on-post-dates
     (let [index-name   "tweets"

--- a/test/clojurewerkz/elastisch/rest_api/queries/query_string_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/query_string_query_test.clj
@@ -46,7 +46,7 @@
       (is (= 1 (total-hits response)))
       (is (= "5" (-> hits first :_id)))))
 
-  (deftest ^{:rest true :query true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case1
+  (deftest ^{:rest true :query true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case2
     (let [index-name   "tweets"
           mapping-type "tweet"
           response (doc/search conn index-name mapping-type :query (q/query-string :query "cloud AND (NOT adoption)"))

--- a/test/clojurewerkz/elastisch/rest_api/update_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/update_test.clj
@@ -55,8 +55,8 @@
         (is (= "brilliant2"
                (get-in (doc/get conn index-name index-type id) [:_source :biography])))
         ;; Can't perform a write when we pass the wrong version
-        (= "VersionConflictEngineException"
-           (:error (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant3") :version original-version)))
+        (is (= "VersionConflictEngineException"
+               (:error (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant3") :version original-version))))
         ;; Still should have the new data
         (is (= "brilliant2" (get-in (doc/get conn index-name index-type id) [:_source :biography]))))))
 


### PR DESCRIPTION
In query_string_query_test.clj, the same name was used for two
deftests, which causes tests in all but the last deftest with the same
name to be ignored.

update_test.clj had (= x y) expression without an (is ...) around it,
so it could never cause tests to fail.

facets_test.clj had incorrect parentheses leading to two expressions
of the form (is (>= expr)), which can never fail unless an exception
is thrown.
