### PR TITLE
Argument added to build-local-node to support 'non-client mode'

### DIFF
--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -267,11 +267,11 @@
        tc)))
 
 (defn ^Node build-local-node
-  [settings]
+  [settings & {:keys [client] :or {client true}}]
   (let [is (cnv/->settings settings)
         nb (.. NodeBuilder nodeBuilder
                (settings is)
-               (client true))]
+               (client client))]
     (.build ^NodeBuilder nb)))
 
 (defn ^Thread start-local-node


### PR DESCRIPTION
Previous codebase hardcoded the client flag in build-local-node to true. Nodes built this way do not support data storage and cannot be elected as master of the cluster. 

For the purposes of running a local node 'in process' using the repl it is useful to be able to run a node that is *not* in client mode. 

This PR adds an optional parameter to the build-local-node function to support this. 

    (build-local-node {} :client false)