### PR TITLE
Added stop-local-node function and fixed type hint

### DIFF
--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -274,9 +274,14 @@
                (client client))]
     (.build ^NodeBuilder nb)))
 
-(defn ^Thread start-local-node
+(defn ^Node start-local-node
   [^Node node]
   (.start node)
+  node)
+
+(defn ^Node stop-local-node
+  [^Node node]
+  (.stop node)
   node)
 
 (defn ^Client connect-to-local-node


### PR DESCRIPTION
Main change is the addition of a stop-local-node function to pair up with start-local-node. Not only does this provide balance, but not forcing the user to use the java-interop (.stop node) gives better encapsulation of the ES API and makes mocking easier. 

I also fixed the type hint, ^Thread didn't seem correct unless I am missing something that is not obvious. 