### PR TITLE
Adds top_hits aggregation to the native client

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -57,6 +57,7 @@
            org.elasticsearch.search.aggregations.metrics.max.Max
            org.elasticsearch.search.aggregations.metrics.min.Min
            org.elasticsearch.search.aggregations.metrics.sum.Sum
+           org.elasticsearch.search.aggregations.metrics.tophits.TopHits
            [org.elasticsearch.search.aggregations.metrics.percentiles Percentiles Percentile]
            org.elasticsearch.search.aggregations.metrics.cardinality.Cardinality
            org.elasticsearch.search.aggregations.metrics.valuecount.ValueCount
@@ -1038,6 +1039,10 @@
      :sum_of_squares (.getSumOfSquares agg)
      :variance       (.getVariance agg)
      :std_deviation  (.getStdDeviation agg)})
+
+  TopHits
+  (aggregation-value [^TopHits agg]
+    {:hits (search-hits->seq (.getHits agg))})
 
   Histogram
   (aggregation-value [^Histogram agg]

--- a/test/clojurewerkz/elastisch/native_api/aggregations/top_hits_aggregations_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/top_hits_aggregations_test.clj
@@ -1,0 +1,24 @@
+(ns clojurewerkz.elastisch.native-api.aggregations.avg-aggregation-test
+  (:require [clojurewerkz.elastisch.native.document :as doc]
+            [clojurewerkz.elastisch.query         :as q]
+            [clojurewerkz.elastisch.aggregation   :as a]
+            [clojurewerkz.elastisch.fixtures      :as fx]
+            [clojurewerkz.elastisch.test.helpers  :as th]
+            [clojure.test :refer :all]
+            [clojurewerkz.elastisch.native.response :refer :all]))
+
+(use-fixtures :each fx/reset-indexes fx/prepopulate-articles-index)
+
+(let [conn (th/connect-native-client)]
+  (deftest ^{:native true :aggregation true} test-top-hits-aggregation
+    (let [index-name   "articles"
+          mapping-type "article"
+          response     (doc/search conn index-name mapping-type
+                                   :query (q/match-all)
+                                   :aggregations
+                                   {:top-hits
+                                    {:top_hits {:sort [{:title {:order "asc"}}]
+                                                :size 4}}})
+          agg          (aggregation-from response :top-hits)]
+      (is (= 4 (get-in agg [:hits :total])))
+      (is (= 4 (count (get-in agg [:hits :hits])))))))


### PR DESCRIPTION
This PR is to support [top_hits](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html)  aggregation results. I am reusing the mapping you guys already wrote. I am open to suggestions if anything is not to your liking. 

I have one remark though there is one test that is failing:
```
FAIL in (test-extended-stats-aggregation) (extended_stats_aggregation_test.clj:29)
expected: (= #{:min :variance :std_deviation :max :count :avg :sum_of_squares :sum} (set (keys agg)))
  actual: (not (= #{:min :variance :std_deviation :max :count :avg :sum_of_squares :sum} #{:min :std_deviation_bounds :variance :std_deviation :max :count :avg :sum_of_squares :sum}))
```

But this test also fails with a clean checkout on my laptop..

Thanks for the awesome library :+1: 
