### PR TITLE
fix large scroll-id using post-string instead of get

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurewerkz/elastisch "2.1.0"
+(defproject clojurewerkz/elastisch "2.1.1-SNAPSHOT"
   :url "http://clojureelasticsearch.info"
   :description "Minimalistic fully featured well documented Clojure ElasticSearch client"
   :license {:name "Eclipse Public License"}

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -221,10 +221,11 @@
   [^Connection conn scroll-id & args]
   (let [opts (ar/->opts args)
         qk   [:search_type :scroll :routing :preference]
-        qp   (assoc (select-keys opts qk) :scroll_id scroll-id)
-        body (apply dissoc (concat [opts] qk))]
-    (rest/get conn (rest/scroll-url conn)
-              {:query-params qp})))
+        qp   (select-keys opts qk)
+        body scroll-id]
+    (rest/post-string conn (rest/scroll-url conn)
+                      {:body body
+                       :query-params qp})))
 
 (defn scroll-seq
   "Returns a lazy sequence of all documents for a given scroll query"


### PR DESCRIPTION
hello,
here is a fix proposal for issue #150 based on tag v2.1.0.

I just give the scroll-id in the body, as documented here http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html