### PR TITLE
fix large scroll-id using post-string instead of get

### DIFF
--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -221,10 +221,11 @@
   [^Connection conn scroll-id & args]
   (let [opts (ar/->opts args)
         qk   [:search_type :scroll :routing :preference]
-        qp   (assoc (select-keys opts qk) :scroll_id scroll-id)
-        body (apply dissoc (concat [opts] qk))]
-    (rest/get conn (rest/scroll-url conn)
-              {:query-params qp})))
+        qp   (select-keys opts qk)
+        body scroll-id]
+    (rest/post-string conn (rest/scroll-url conn)
+                      {:body body
+                       :query-params qp})))
 
 (defn scroll-seq
   "Returns a lazy sequence of all documents for a given scroll query"


### PR DESCRIPTION
redone from 2.1.x-stable