### PR TITLE
Better alias syntax

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1415,11 +1415,13 @@
 
 
 (defn- apply-add-alias
-  [^IndicesAliasesRequest req {:keys [index indices alias filter]}]
-  (let [indices-array (->string-array (or indices index))]
-    (if filter
-      (.addAlias req ^String alias ^Map filter indices-array)
-      (.addAlias req ^String alias indices-array)))
+  [^IndicesAliasesRequest req {:keys [index indices alias aliases filter]}]
+  (let [indices-array (->string-array (or indices index))
+        aliases-array (->string-array (or aliases alias))]
+    (doseq [alias aliases-array]
+      (if filter
+        (.addAlias req ^String alias ^Map filter indices-array)
+        (.addAlias req ^String alias indices-array))))
   req)
 
 (defn- apply-remove-alias

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1425,8 +1425,11 @@
   req)
 
 (defn- apply-remove-alias
-  [^IndicesAliasesRequest req {:keys [index alias aliases]}]
-  (.removeAlias req ^String index (->string-array (or aliases alias)))
+  [^IndicesAliasesRequest req {:keys [index indices alias aliases]}]
+  (let [indices-array (->string-array (or indices index))
+        aliases-array (->string-array (or aliases alias))]
+    (doseq [index indices-array]
+      (.removeAlias req ^String index aliases-array)))
   req)
 
 (defn ^IndicesAliasesRequest ->indices-aliases-request

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1425,8 +1425,8 @@
   req)
 
 (defn- apply-remove-alias
-  [^IndicesAliasesRequest req {:keys [index aliases]}]
-  (.removeAlias req ^String index (->string-array aliases))
+  [^IndicesAliasesRequest req {:keys [index alias aliases]}]
+  (.removeAlias req ^String index (->string-array (or aliases alias)))
   req)
 
 (defn ^IndicesAliasesRequest ->indices-aliases-request

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -129,6 +129,13 @@
   (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices ["aliased-index"]}}
                                                {:add {:alias "alias2" :indices ["aliased-index"]}}]))))
 
+(deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases-using-plural-aliases-syntax 
+  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+  (is (acknowledged? (idx/update-aliases conn [{:add {:aliases ["alias1" "alias2"] :index "aliased-index"}}])))
+  (is (doc/put conn "aliased-index" "type" "id1" {}))
+  (is (doc/get conn "alias1" "type" "id1"))
+  (is (doc/get conn "alias2" "type" "id1")))
+
 (deftest ^{:indexing true :native true} test-create-an-index-with-an-alias-and-delete-it
   (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
   (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -141,6 +141,11 @@
   (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))
   (is (acknowledged? (idx/update-aliases conn [{:remove {:aliases "alias1" :index "aliased-index"}}]))))
 
+(deftest ^{:indexing true :native true} test-remove-alias-allows-singular-alias
+  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+  (is (acknowledged? (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}])))
+  (is (acknowledged? (idx/update-aliases conn [{:remove {:index "aliased-index" :alias "alias1"}}]))))
+
 (deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
   (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
     (is (acknowledged? response))))

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -146,6 +146,12 @@
   (is (acknowledged? (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}])))
   (is (acknowledged? (idx/update-aliases conn [{:remove {:index "aliased-index" :alias "alias1"}}]))))
 
+(deftest ^{:indexing true :native true} test-remove-alias-allows-multiple-indices
+  (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
+  (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
+  (is (acknowledged? (idx/update-aliases conn [{:add {:indices ["aliased-index1" "aliased-index2"] :alias "alias"}}])))
+  (is (acknowledged? (idx/update-aliases conn [{:remove {:alias "alias" :indices ["aliased-index1" "aliased-index2"]}}]))))
+
 (deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
   (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
     (is (acknowledged? response))))


### PR DESCRIPTION
Allows one to use following syntax with native api's `update-aliases`:

```(update-aliases conn [{:add {:index "index" :aliases ["alias1" "alias2"]}}])```

and

```(update-aliases conn [{:remove {:index "index" :aliases ["alias1" "alias2"]}}])```

This matches my interpretation of the current documentation for `update-aliases`

Fixes #155 