### PR TITLE
Allow index settings to have keywordized keys with using esi/create

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,12 @@ Elastisch now depends on ElasticSearch Java client version `1.5.x`.
 
 Contributed by @mnylen
 
+### Index settings now allow keywordized keys when creating index using native api
+
+Previously only mappings allowed keys to be keywords, now same works with index settings.
+
+Contributed by @mnylen
+
 ## Changes between Elastisch 2.2.0-beta2 and 2.2.0-beta3
 
 ### Support for Large Scroll IDs

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1180,9 +1180,10 @@
 (defn ^CreateIndexRequest ->create-index-request
   [index-name settings mappings]
   (let [r (CreateIndexRequest. index-name)
+        s (wlk/stringify-keys settings)
         m (wlk/stringify-keys mappings)]
     (when settings
-      (.settings r ^Map settings))
+      (.settings r ^Map s))
     (when mappings
       (doseq [[k v] m]
         (.mapping r ^String k ^Map v)))

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -35,6 +35,10 @@
   (let [response (idx/create conn "elastisch-index-without-mappings" :settings {"index" {"number_of_shards" 1}})]
     (is (acknowledged? response))))
 
+(deftest ^{:indexing true :native true} test-create-index-accepts-keywordized-keys-in-settings
+  (let [response (idx/create conn "elastisch-index-with-settings" :settings {:index {:refresh_interval "42s"}})]
+    (is (acknowledged? response))))
+
 (deftest ^{:indexing true :native true} test-successful-creation-of-index-with-mappings-and-without-settings
   (let [index    "people"
         response (idx/create conn index :mappings fx/people-mapping)]


### PR DESCRIPTION
Mappings allows keywordized keys, so it's just consistent to allow same for index settings

Fix #158 