### PR TITLE
add support for bulk create operation

### DIFF
--- a/src/clojurewerkz/elastisch/common/bulk.clj
+++ b/src/clojurewerkz/elastisch/common/bulk.clj
@@ -28,6 +28,10 @@
   [doc]
   {"index" (select-keys doc special-operation-keys)})
 
+(defn create-operation
+  [doc]
+  {"create" (select-keys doc special-operation-keys)})
+
 (defn update-operation
   [doc]
   {"update" (select-keys doc special-operation-keys)})
@@ -40,6 +44,13 @@
   "generates the content for a bulk insert operation"
   ([documents]
      (let [operations (map index-operation documents)
+           documents  (map #(apply dissoc % special-operation-keys) documents)]
+       (interleave operations documents))))
+
+(defn bulk-create
+  "generates the content for a bulk create operation"
+  ([documents]
+     (let [operations (map create-operation documents)
            documents  (map #(apply dissoc % special-operation-keys) documents)]
        (interleave operations documents))))
 

--- a/src/clojurewerkz/elastisch/native/bulk.clj
+++ b/src/clojurewerkz/elastisch/native/bulk.clj
@@ -81,3 +81,5 @@
 (def bulk-update common-bulk/bulk-update)
 
 (def bulk-delete common-bulk/bulk-delete)
+
+(def bulk-create common-bulk/bulk-create)

--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -57,3 +57,5 @@
 (def bulk-index common-bulk/bulk-index)
 
 (def bulk-delete common-bulk/bulk-delete)
+
+(def bulk-create common-bulk/bulk-create)

--- a/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
@@ -74,4 +74,11 @@
           delete-response (bulk/bulk-with-index-and-type conn index-name index-type (bulk/bulk-delete docs) :refresh true)]
       (is (= 10 initial-count))
       (are-all-successful (->> response :items (map :create)))
-      (is (= 0 (:count (doc/count conn index-name index-type)))))))
+      (is (= 0 (:count (doc/count conn index-name index-type))))))
+
+  (deftest ^{:rest true :indexing true} test-bulk-create
+    (let [document          fx/person-jack
+          for-index         (assoc document :_type index-type :_id "sampleid")
+          create-operations (bulk/bulk-create (repeat 10 for-index))
+          response          (bulk/bulk-with-index conn index-name create-operations {:refresh true})]
+      (is (= 1 (:count (doc/count conn index-name index-type)))))))


### PR DESCRIPTION
hello,

bulk operations, such as described in the elasticsearch docs (  https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html ) , support 4 operations : index / update / delete / create.

I've added the helpers for create operation, like it was done for others operations.