### PR TITLE
Support the ignoreUnmapped feature when sorting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,24 @@ Bulk operation helper functions now include `create`.
 
 Contributed by @nikopol.
 
+### allow setting `:ignore-unmapped` in query sort instructions
+
+In both native and rest apis, `:ignore-unmapped` may be set in the query by specifying
+a sort field-name and option-map instead of order name with the `query/sort` function.
+For example:
+
+
+``` clojure
+(require '[clojurewerkz.elastisch.native.document :as doc])
+(require '[clojurewerkz.elastisch.query :as q])
+
+(doc/search conn index type
+            {:query (q/query-string :query "software" :default_field "summary")
+             :sort  (q/sort "unmapped-field-name" {:ignore-unmapped true
+                                                   :order "asc"})})
+```
+
+Contributed by @ryfow
 
 ## Changes between Elastisch 2.2.0-beta3 and 2.2.0-beta4
 

--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -16,8 +16,9 @@
   "Convenience functions that build various query types.
 
    All functions return maps and are completely optional (but recommended)."
-  (:refer-clojure :exclude [range])
-  (:require [clojurewerkz.elastisch.escape    :as escape]
+  (:refer-clojure :exclude [range sort])
+  (:require [clojure.set :as set]
+            [clojurewerkz.elastisch.escape    :as escape]
             [clojurewerkz.elastisch.arguments :as ar]))
 
 (defn term
@@ -239,3 +240,12 @@
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html"
   [& args]
   {:nested (ar/->opts args)})
+
+(defn sort
+  "Sort query results."
+  [attribute {:keys [ignore-unmapped order] :as v}]
+  {attribute
+   (cond (map? v)
+         (set/rename-keys v {:ignore-unmapped :ignoreUnmapped})
+         :default
+         v)})

--- a/test/clojurewerkz/elastisch/native_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_test.clj
@@ -112,4 +112,14 @@
                                                                    "planet" "biography"
                                                                    "last-name" "username"]}))]
       (is (= 4 (count hits)))
-      (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source))))))))
+      (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source)))))))
+
+  (deftest ^{:native true} test-sorting-on-unmapped-field
+    (let [index-name   "people"
+          mapping-type "person"
+          hits         (hits-from (doc/search conn index-name mapping-type
+                                              :query   (q/match-all)
+                                              :sort    (q/sort "surname"
+                                                               {:order "asc"
+                                                                :ignore-unmapped true})))]
+      (is (= 4 (count hits))))))

--- a/test/clojurewerkz/elastisch/rest_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_test.clj
@@ -91,4 +91,14 @@
                                                                    "planet" "biography"
                                                                    "last-name" "username"]}))]
       (is (= 4 (count hits)))
-      (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source))))))))
+      (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source)))))))
+
+  (deftest ^{:rest true} test-sorting-on-unmapped-field
+    (let [index-name   "people"
+          mapping-type "person"
+          hits         (hits-from (doc/search conn index-name mapping-type
+                                              :query   (q/match-all)
+                                              :sort    (q/sort "surname"
+                                                               {:order "asc"
+                                                                :ignore-unmapped true})))]
+      (is (= 4 (count hits))))))


### PR DESCRIPTION
This lets you control the ignoreUnmapped feature of FieldSortBuilder
when sorting on a field. When requesting a sort, call q/sort with the
field-name and options map, including an :order and :ignore-unmapped
options.

The tests show usage.

This is a small patch, but I made a few decisions that probably need review by someone that knows the codebase. The most questionable parts revolve around changing `:ignore-unmapped` to `ignoreUnmapped` in the rest api. What I did was add a `sort` function to `query` that uses `clojure.set/rename-keys` to modify the map.

Otherwise I tried to follow your coding style, but am not sure of what all is important.

Please let me know what you want changed before accepting. I'll be happy to write docs once the code changes are approved.

Thanks!
