### PR TITLE
Add scan-and-scroll-seq function.

### DIFF
--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -255,6 +255,25 @@
       (concat hits (lazy-seq (scroll-seq conn (scroll conn scroll-id :scroll "1m"))))
       hits)))
 
+(defn scan-and-scroll-seq
+  "An abstraction over the scan-and-scroll API. Retrieves the scroll
+   id via an initial scan search, retrieves the first batch of responses
+   using that id, then calls scroll-seq to continue retrieving responses
+   lazily until there are no more hits."
+  [^Connection conn index doc-type & args]
+  (let [opts              (ar/->opts args)
+        query             (merge opts
+                                 {:scroll "1m"})
+        initial-scroll-id (->> (merge {:size 1000}
+                                      query
+                                      {:search_type "scan"})
+                               (search conn index doc-type)
+                               :_scroll_id)
+        first-resp        (scroll conn
+                                  initial-scroll-id
+                                  query)]
+    (scroll-seq conn first-resp)))
+
 (defn replace
   "Replaces document with given id with a new one"
   [^Connection conn index mapping-type id document]

--- a/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
@@ -104,4 +104,15 @@
                                                    :scroll "1m"
                                                    :size 2))]
       (is (= 0 (count res-seq)))
-      (is (coll? res-seq)))))
+      (is (coll? res-seq))))
+
+  (deftest ^{:rest true :scroll true} test-scan-and-scroll-seq
+    (let [index-name   "articles"
+          mapping-type "article"
+          res-seq       (doc/scan-and-scroll-seq conn index-name mapping-type
+                                                 :query (q/match-all)
+                                                 :size 2)]
+      (is (not (realized? res-seq)))
+      (is (= 4 (count res-seq)))
+      (is (= 4 (count (distinct res-seq))))
+      (is (realized? res-seq)))))


### PR DESCRIPTION
This takes care of the inconsistency between scroll-seq and ES's
scan-and-scroll API, referenced in issue #72. The new function makes an
initial request of search_type "scan" to the search api in order to
obtain the first scroll id, makes a second request to retrieve the first
batch of results, and then hands off to scroll-seq to continue lazily
retrieving batches. It is necessary to retrieve one batch initially
because the first request is a special case, as described in that issue
-- it always returns no hits.