### PR TITLE
Add scan-and-scroll-seq to native api.

### DIFF
--- a/src/clojurewerkz/elastisch/native/document.clj
+++ b/src/clojurewerkz/elastisch/native/document.clj
@@ -352,6 +352,24 @@
       (concat hits (lazy-seq (scroll-seq conn (scroll conn scroll-id :scroll "1m"))))
       hits)))
 
+(defn scan-and-scroll-seq
+   "An abstraction over the scan-and-scroll API. Retrieves the scroll
+   id via an initial scan search, retrieves the first batch of responses
+   using that id, then calls scroll-seq to continue retrieving responses
+   lazily until there are no more hits."
+  [^Client conn index mapping-type & args]
+  (let [query (merge (ar/->opts args)
+                     {:scroll "1m"})
+        initial-scroll-id (->> (merge {:size 1000}
+                                      query
+                                      {:search_type "scan"})
+                               (search conn index mapping-type)
+                               :_scroll_id)
+        first-resp (scroll conn
+                           initial-scroll-id
+                           query)]
+    (scroll-seq conn first-resp)))
+
 (defn replace
   "Replaces document with given id with a new one"
   [^Client conn index mapping-type id document]

--- a/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
@@ -98,5 +98,16 @@
                                    :scroll "1m"
                                    :size 2))]
     (is (= 0 (count res-seq)))
-    (is (= true (coll? res-seq))))))
+    (is (= true (coll? res-seq)))))
+
+(deftest ^{:native true :scroll true} test-scan-and-scroll-seq
+    (let [index-name   "articles"
+          mapping-type "article"
+          res-seq       (doc/scan-and-scroll-seq conn index-name mapping-type
+                                                 :query (q/match-all)
+                                                 :size 2)]
+      (is (not (realized? res-seq)))
+      (is (= 4 (count res-seq)))
+      (is (= 4 (count (distinct res-seq))))
+      (is (realized? res-seq)))))
 


### PR DESCRIPTION
Corresponding to 6f41a63 adding scan-and-scroll-seq to the REST API.

(Wasn't sure to add on to the existing PR once merged -- sorry for the duplication.)