### PR TITLE
fix argument's type error for indices/close and open function;

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 ## Changes between Elastisch 2.1.x and 2.2.0
 
+### Fixed `index/close` and `index/open` argument type error
+
+  `clojurewerkz.elastisch.native.conversion/->open-index-request` and  `->close-index-request`
+  passed plain string to [CloseIndexRequest](http://javadoc.kyubu.de/elasticsearch/HEAD/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.html) constructor, but it expected values passed as array of string.
+  Fixed it with existing function `conversion/->string-array` and added missing tests for this usecase
+  into `clojurewerkz.elastisch.native-api.indices-settings-test`.
+
+  Contributed by Timo Sulg (@timgluz)
+
 ### Fixed `update-with-script` in Native Client
 
 `clojurewerkz.elastisch.native.conversion/->update-request` arguments

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1286,12 +1286,14 @@
     (.types (->string-array mapping-types))))
 
 (defn ^OpenIndexRequest ->open-index-request
+  "opens closed index or indices for search"
   [index-name]
-  (OpenIndexRequest. index-name))
+  (OpenIndexRequest. (->string-array index-name)))
 
 (defn ^CloseIndexRequest ->close-index-request
+  "closes index or indices for updating"
   [index-name]
-  (CloseIndexRequest. index-name))
+  (CloseIndexRequest. (->string-array index-name)))
 
 (defn ^OptimizeRequest ->optimize-index-request
   [index-name {:keys [max-num-segments only-expunge-deletes flush]}]

--- a/src/clojurewerkz/elastisch/native/index.clj
+++ b/src/clojurewerkz/elastisch/native/index.clj
@@ -146,14 +146,17 @@
 (defn open
   "Opens an index"
   [^Client conn index-name]
-  (let [ft                     (es/admin-open-index conn (cnv/->open-index-request index-name))
+  (let [ft (es/admin-open-index conn (cnv/->open-index-request index-name))
         ^OpenIndexResponse res (.actionGet ft)]
     {:ok (.isAcknowledged res) :acknowledged (.isAcknowledged res)}))
 
 (defn close
-  "Closes an index"
+  "Closes an index or indices
+  Usage:
+    (idx/close conn \"my-index\")
+    (idx/close conn [\"my-index\" \"dein-index\"])"
   [^Client conn index-name]
-  (let [ft                     (es/admin-close-index conn (cnv/->close-index-request index-name))
+  (let [ft (es/admin-close-index conn (cnv/->close-index-request index-name))
         ^CloseIndexResponse res (.actionGet ft)]
     {:ok (.isAcknowledged res) :acknowledged (.isAcknowledged res)}))
 

--- a/test/clojurewerkz/elastisch/native_api/indices_settings_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_settings_test.clj
@@ -1,0 +1,32 @@
+;; Copyright (c) 2011-2015 Michael S. Klishin, Alex Petrov, and the ClojureWerkz Team
+;;
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns clojurewerkz.elastisch.native-api.indices-settings-test
+  (:require [clojurewerkz.elastisch.native        :as es]
+            [clojurewerkz.elastisch.native
+              [document :as doc]
+              [index :as idx]
+              [response :refer [acknowledged?]]]
+            [clojurewerkz.elastisch.fixtures      :as fx]
+            [clojurewerkz.elastisch.test.helpers  :as th]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each fx/reset-indexes fx/prepopulate-people-index)
+
+(let [conn (th/connect-native-client)
+      index-name "people"]
+  (deftest ^{:indexing true :native true} test-closing-and-opening-existing-index 
+    (testing "it should close people's index" 
+      (let [res (idx/close conn index-name)]
+        (is (acknowledged? res))))
+
+    (testing "it should open people's index"
+      (let [res (idx/open conn index-name)]
+        (is (acknowledged? res))))))
+

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -10,9 +10,9 @@
 (ns clojurewerkz.elastisch.native-api.indices-test
   (:require [clojurewerkz.elastisch.native        :as es]
             [clojurewerkz.elastisch.native
-             [document :as doc]
-             [index :as idx]
-             [response :refer [acknowledged?]]]
+              [document :as doc]
+              [index :as idx]
+              [response :refer [acknowledged?]]]
             [clojurewerkz.elastisch.fixtures      :as fx]
             [clojurewerkz.elastisch.test.helpers  :as th]
             [clojure.test :refer :all]))
@@ -27,139 +27,140 @@
 
 (let [conn (th/connect-native-client)]
   (deftest ^{:indexing true :native true} test-create-an-index-without-mappings-or-settings
-  (let [response (idx/create conn "elastisch-index-without-mappings")]
-    (is (acknowledged? response))
-    (is (not (idx/type-exists? conn "elastisch-index-without-mappings" "person")))))
+    (let [response (idx/create conn "elastisch-index-without-mappings")]
+      (is (acknowledged? response))
+      (is (not (idx/type-exists? conn "elastisch-index-without-mappings" "person")))))
 
-(deftest ^{:indexing true :native true} test-create-an-index-with-settings
-  (let [response (idx/create conn "elastisch-index-without-mappings" :settings {"index" {"number_of_shards" 1}})]
-    (is (acknowledged? response))))
+  (deftest ^{:indexing true :native true} test-create-an-index-with-settings
+    (let [response (idx/create conn "elastisch-index-without-mappings" :settings {"index" {"number_of_shards" 1}})]
+      (is (acknowledged? response))))
 
-(deftest ^{:indexing true :native true} test-create-index-accepts-keywordized-keys-in-settings
-  (let [response (idx/create conn "elastisch-index-with-settings" :settings {:index {:refresh_interval "42s"}})]
-    (is (acknowledged? response))))
+  (deftest ^{:indexing true :native true} test-create-index-accepts-keywordized-keys-in-settings
+    (let [response (idx/create conn "elastisch-index-with-settings" :settings {:index {:refresh_interval "42s"}})]
+      (is (acknowledged? response))))
 
-(deftest ^{:indexing true :native true} test-successful-creation-of-index-with-mappings-and-without-settings
-  (let [index    "people"
-        response (idx/create conn index :mappings fx/people-mapping)]
-    (is (idx/exists? conn index))
-    (is (idx/type-exists? conn index "person"))))
+  (deftest ^{:indexing true :native true} test-successful-creation-of-index-with-mappings-and-without-settings
+    (let [index    "people"
+          response (idx/create conn index :mappings fx/people-mapping)]
+      (is (idx/exists? conn index))
+      (is (idx/type-exists? conn index "person"))))
 
-(deftest ^{:indexing true :native true} test-successful-deletion-of-index
-  (let [index    "people"
-        _        (idx/create conn index :mappings fx/people-mapping)
-        response (idx/delete conn index)]
-    (is (not (idx/exists? conn index)))))
+  (deftest ^{:indexing true :native true} test-successful-deletion-of-index
+    (let [index    "people"
+          _        (idx/create conn index :mappings fx/people-mapping)
+          response (idx/delete conn index)]
+      (is (not (idx/exists? conn index)))))
 
-(deftest ^{:native true :indexing true} test-getting-index-settings
+  (deftest ^{:native true :indexing true} test-getting-index-settings
+      (let [index     "people"
+            settings  {"index" {"refresh_interval" "1s"}}
+            response  (idx/create conn index :settings settings :mappings fx/people-mapping)
+            settings' (idx/get-settings conn "people")]
+        (acknowledged? response)
+        (is (= "1s" (get-in settings' [:people :settings :index :refresh_interval])))))
+
+  (deftest ^{:indexing true :native true} testing-updating-specific-index-settings
     (let [index     "people"
-          settings  {"index" {"refresh_interval" "1s"}}
-          response  (idx/create conn index :settings settings :mappings fx/people-mapping)
-          settings' (idx/get-settings conn "people")]
-      (acknowledged? response)
-      (is (= "1s" (get-in settings' [:people :settings :index :refresh_interval])))))
+          settings  {:index {:refresh_interval "1s"}}
+          _         (idx/create conn index :mappings fx/people-mapping)]
+      (is (idx/update-settings conn index settings))))
 
-(deftest ^{:indexing true :native true} testing-updating-specific-index-settings
-  (let [index     "people"
-        settings  {:index {:refresh_interval "1s"}}
-        _         (idx/create conn index :mappings fx/people-mapping)]
-    (is (idx/update-settings conn index settings))))
+  (deftest ^{:indexing true :native true} test-optimize-index
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)
+          response  (idx/optimize conn index :only_expunge_deletes 1)]
+      (is (broadcast-operation-response? response))))
 
-(deftest ^{:indexing true :native true} test-optimize-index
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)
-        response  (idx/optimize conn index :only_expunge_deletes 1)]
-    (is (broadcast-operation-response? response))))
+  (deftest ^{:indexing true :native true} test-flush-index
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)
+          response  (idx/flush conn index)]
+      (is (broadcast-operation-response? response))))
 
-(deftest ^{:indexing true :native true} test-flush-index
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)
-        response  (idx/flush conn index)]
-    (is (broadcast-operation-response? response))))
+  (deftest ^{:indexing true :native true} test-refresh-index
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)
+          response  (idx/refresh conn index)]
+      (is (broadcast-operation-response? response))))
 
-(deftest ^{:indexing true :native true} test-refresh-index
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)
-        response  (idx/refresh conn index)]
-    (is (broadcast-operation-response? response))))
+  (deftest ^{:indexing true :native true} test-clear-index-cache-with-refresh
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)
+          response  (idx/clear-cache conn index :filter true :field_data true)]
+      (is (broadcast-operation-response? response))))
 
-(deftest ^{:indexing true :native true} test-clear-index-cache-with-refresh
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)
-        response  (idx/clear-cache conn index :filter true :field_data true)]
-    (is (broadcast-operation-response? response))))
+  (deftest ^{:indexing true :native true} test-index-status-1
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)
+          response  (idx/status conn index :recovery true)]
+      (is (broadcast-operation-response? response))))
 
-(deftest ^{:indexing true :native true} test-index-status-1
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)
-        response  (idx/status conn index :recovery true)]
-    (is (broadcast-operation-response? response))))
+  (deftest ^{:indexing true :native true} test-index-status-for-multiple-indexes-1
+    (idx/create conn "group1")
+    (idx/create conn "group2")
+    (is (broadcast-operation-response? (idx/status conn ["group1" "group2"] :recovery true :snapshot true))))
 
-(deftest ^{:indexing true :native true} test-index-status-for-multiple-indexes-1
-  (idx/create conn "group1")
-  (idx/create conn "group2")
-  (is (broadcast-operation-response? (idx/status conn ["group1" "group2"] :recovery true :snapshot true))))
+  (deftest ^{:indexing true :native true} test-index-status-2
+    (let [index     "people"
+          _         (idx/create conn index :mappings fx/people-mapping)]
+      (is (broadcast-operation-response? (idx/segments conn index)))))
 
-(deftest ^{:indexing true :native true} test-index-status-2
-  (let [index     "people"
-        _         (idx/create conn index :mappings fx/people-mapping)]
-    (is (broadcast-operation-response? (idx/segments conn index)))))
+  (deftest ^{:indexing true :native true} test-index-status-for-multiple-indexes-2
+    (idx/create conn "group1")
+    (idx/create conn "group2")
+    (is (broadcast-operation-response? (idx/segments conn ["group1" "group2"]))))
 
-(deftest ^{:indexing true :native true} test-index-status-for-multiple-indexes-2
-  (idx/create conn "group1")
-  (idx/create conn "group2")
-  (is (broadcast-operation-response? (idx/segments conn ["group1" "group2"]))))
+  (deftest ^{:indexing true :native true} test-index-stats-for-all-indexes
+    (idx/create conn "group1")
+    (idx/create conn "group2")
+    (is (idx/stats conn :docs true :store true :indexing true)))
 
-(deftest ^{:indexing true :native true} test-index-stats-for-all-indexes
-  (idx/create conn "group1")
-  (idx/create conn "group2")
-  (is (idx/stats conn :docs true :store true :indexing true)))
+  (deftest ^{:indexing true :native true} test-indices-with-aliases
+    (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged?
+          (idx/update-aliases conn [{:add {:alias "alias1" :index "aliased-index1"}}
+                                    {:add {:alias "alias2" :index "aliased-index2"}}])))
+    (is (doc/put conn "aliased-index1" "type" "id1" {}))
+    (is (doc/put conn "aliased-index2" "type" "id2" {}))
+    (is (doc/get conn "alias1" "type" "id1"))
+    (is (doc/get conn "alias2" "type" "id2"))
+    (is (not (doc/get conn "alias1" "type" "id2")))
+    (is (not (doc/get conn "alias2" "type" "id1"))))
 
-(deftest ^{:indexing true :native true} test-indices-with-aliases
-  (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
-  (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged?
-        (idx/update-aliases conn [{:add {:alias "alias1" :index "aliased-index1"}}
-                                  {:add {:alias "alias2" :index "aliased-index2"}}])))
-  (is (doc/put conn "aliased-index1" "type" "id1" {}))
-  (is (doc/put conn "aliased-index2" "type" "id2" {}))
-  (is (doc/get conn "alias1" "type" "id1"))
-  (is (doc/get conn "alias2" "type" "id2"))
-  (is (not (doc/get conn "alias1" "type" "id2")))
-  (is (not (doc/get conn "alias2" "type" "id1"))))
+  (deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases
+    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices ["aliased-index"]}}
+                                                 {:add {:alias "alias2" :indices ["aliased-index"]}}]))))
 
-(deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases
-  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices ["aliased-index"]}}
-                                               {:add {:alias "alias2" :indices ["aliased-index"]}}]))))
+  (deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases-using-plural-aliases-syntax 
+    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged? (idx/update-aliases conn [{:add {:aliases ["alias1" "alias2"] :index "aliased-index"}}])))
+    (is (doc/put conn "aliased-index" "type" "id1" {}))
+    (is (doc/get conn "alias1" "type" "id1"))
+    (is (doc/get conn "alias2" "type" "id1")))
 
-(deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases-using-plural-aliases-syntax 
-  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged? (idx/update-aliases conn [{:add {:aliases ["alias1" "alias2"] :index "aliased-index"}}])))
-  (is (doc/put conn "aliased-index" "type" "id1" {}))
-  (is (doc/get conn "alias1" "type" "id1"))
-  (is (doc/get conn "alias2" "type" "id1")))
+  (deftest ^{:indexing true :native true} test-create-an-index-with-an-alias-and-delete-it
+    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))
+    (is (acknowledged? (idx/update-aliases conn [{:remove {:aliases "alias1" :index "aliased-index"}}]))))
 
-(deftest ^{:indexing true :native true} test-create-an-index-with-an-alias-and-delete-it
-  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))
-  (is (acknowledged? (idx/update-aliases conn [{:remove {:aliases "alias1" :index "aliased-index"}}]))))
+  (deftest ^{:indexing true :native true} test-remove-alias-allows-singular-alias
+    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged? (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}])))
+    (is (acknowledged? (idx/update-aliases conn [{:remove {:index "aliased-index" :alias "alias1"}}]))))
 
-(deftest ^{:indexing true :native true} test-remove-alias-allows-singular-alias
-  (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged? (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}])))
-  (is (acknowledged? (idx/update-aliases conn [{:remove {:index "aliased-index" :alias "alias1"}}]))))
+  (deftest ^{:indexing true :native true} test-remove-alias-allows-multiple-indices
+    (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
+    (is (acknowledged? (idx/update-aliases conn [{:add {:indices ["aliased-index1" "aliased-index2"] :alias "alias"}}])))
+    (is (acknowledged? (idx/update-aliases conn [{:remove {:alias "alias" :indices ["aliased-index1" "aliased-index2"]}}]))))
 
-(deftest ^{:indexing true :native true} test-remove-alias-allows-multiple-indices
-  (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
-  (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
-  (is (acknowledged? (idx/update-aliases conn [{:add {:indices ["aliased-index1" "aliased-index2"] :alias "alias"}}])))
-  (is (acknowledged? (idx/update-aliases conn [{:remove {:alias "alias" :indices ["aliased-index1" "aliased-index2"]}}]))))
+  (deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
+    (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
+      (is (acknowledged? response))))
 
-(deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
-  (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
-    (is (acknowledged? response))))
+  (deftest ^{:indexing true :native true} test-create-an-index-template-and-delete-it
+     (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})
+     (is (acknowledged? (idx/delete-template conn "accounts")))))
 
-(deftest ^{:indexing true :native true} test-create-an-index-template-and-delete-it
-   (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})
-   (is (acknowledged? (idx/delete-template conn "accounts")))))

--- a/test/clojurewerkz/elastisch/rest_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/indices_test.clj
@@ -102,6 +102,7 @@
   (deftest ^{:rest true :indexing true} test-index-stats
     (let [index     "people"
           _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/refresh conn index) ;; let's wait until ES has finished indexing
           response  (idx/stats conn index :stats ["docs" "store" "indexing"] :types "person")
           stats     (-> response :_all :primaries)]
       (is (every? #(contains? stats %) [:docs :store :indexing]))


### PR DESCRIPTION
Hi, 

i found a little bug in `native-api.conversion/->close-index-request` and `native-api.conversion/->open-index-request` -> they called a OpenIndexRequest/[CloseIndexRequest](http://javadoc.kyubu.de/elasticsearch/HEAD/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.html)  constructor by string, but it expects array of string.

I just wrapped a index with `native-api.conversion/->string-array` and it passed my tests and made it possible to use my custom analysers.

 I added tests for `native-api.index/close` & `native-api.index/open` - i was forced to put them into own file because indices-test didnt allow me to add another fixture-call; i tried to put them into different let-scope, but it didnt work as well putting my tests into separate file, each with own fixture-call.

* I fixed code lyout in native-api/indices-test as it made difficult to me see let-scope for conn;

* I fixed a little bug in rest-api/indices-tests.

* updated changelog with my changes;