### PR TITLE
Bug fix in overloaded version of ->index-stats-request fn.

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1497,6 +1497,7 @@
   ([{:keys [docs store indexing types groups get
             search merge flush refresh]}]
      (let [r   (IndicesStatsRequest.)]
+       (.clear r)
        (when docs
          (.docs r docs))
        (when store


### PR DESCRIPTION
Overloaded version of ->index-stats-request (with request settings) must initialize flags with false if corresponding request settings were not set to true (or just were not provided)