### PR TITLE
Remove redundant true checks in tests

### DIFF
--- a/test/clojurewerkz/elastisch/native_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/bulk_test.clj
@@ -93,7 +93,7 @@
           for-update (assoc for-insert :_script script)
           update-ops (bulk-update [for-update])
           update-response (bulk-with-index-and-type conn index-name index-type update-ops {:refresh true})]
-      (is (= true (get-in (doc/get conn index-name index-type id) [:_source :ran_script])))))
+      (is (get-in (doc/get conn index-name index-type id) [:_source :ran_script]))))
 
   (deftest ^{:native true :indexing true :scripting true} test-bulk-update-with-scripted-upsert
     (let [id "2"
@@ -101,7 +101,7 @@
           for-update (assoc fx/person-jack :_id id :_scripted_upsert true :_script script)
           update-ops (bulk-update [for-update])
           update-response (bulk-with-index-and-type conn index-name index-type update-ops {:refresh true})]
-      (is (= true (get-in (doc/get conn index-name index-type id) [:_source :ran_script])))))
+      (is (get-in (doc/get conn index-name index-type id) [:_source :ran_script]))))
 
   (deftest ^{:native true :indexing true :scripting true} test-bulk-update-with-script-params
     (let [id "3"

--- a/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
@@ -86,7 +86,7 @@
       (is (= false (realized? res-seq)))
       (is (= 4 (count res-seq)))
       (is (= 4 (count (distinct res-seq))))
-      (is (= true (realized? res-seq)))))
+      (is (realized? res-seq))))
 
   (deftest ^{:native true :scroll true} test-scroll-seq-scan
     (let [index-name "articles"
@@ -101,7 +101,7 @@
       (is (= false (realized? res-seq)))
       (is (= 4 (count res-seq)))
       (is (= 4 (count (distinct res-seq))))
-      (is (= true (realized? res-seq)))))
+      (is (realized? res-seq))))
 
   (deftest ^{:native true :scroll true} test-scroll-seq-with-no-results
     (let [index-name "articles"
@@ -113,5 +113,5 @@
                                               :scroll "1m"
                                               :size 2))]
       (is (= 0 (count res-seq)))
-      (is (= true (coll? res-seq))))))
+      (is (coll? res-seq)))))
 

--- a/test/clojurewerkz/elastisch/native_api/suggest_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/suggest_test.clj
@@ -14,7 +14,7 @@
     (testing "simple autocomplete returns mary's username"
       (let [index-name "people"
             res (doc/suggest conn index-name :completion "esma" {})]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (let [payload (-> res :hits :options first :payload)]
           (is (= "esma" (-> res :hits :text)))
           (is (= "esmary" (:username payload)))
@@ -25,7 +25,7 @@
     (testing "simple fuzzy autocomplete returns mary's username even i had typo"
       (let [index-name "people"
             res (doc/suggest conn index-name :fuzzy "esmor" {:fuzziness 1 :min-length 2})]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (let [payload (-> res :hits :options first :payload)]
           (is (= "esmor" (-> res :hits :text)))
           (is (= "esmary" (:username payload)))
@@ -36,7 +36,7 @@
     (testing "autocomplete filters results by person's gender"
       (let [index-name "people_with_category"
             res (doc/suggest conn index-name :completion "e" {:context {:gender "female"}})]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (is (= 2 (-> res :hits :options count)))
         (is (= "esmary" (-> res :hits :options first :text))))))
 
@@ -45,7 +45,7 @@
       (let [index-name "people_with_locations"
             opts {:context {:location {:lat 90.23 :lon 90.56}}}
             res (doc/suggest conn index-name :completion "es" opts)]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (is (= 1 (-> res :hits :options count)))
         (is (= "esjack" (-> res :hits :options first :text))))))
 
@@ -53,7 +53,7 @@
     (testing "autocomplete filters results by person's gender"
       (let [index-name "people_with_category"
             res (doc/suggest conn index-name :fuzzy "es" {:context {:gender "female"}})]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (is (= 2 (-> res :hits :options count)))
         (is (= "esmary" (-> res :hits :options first :text))))))
 
@@ -62,6 +62,6 @@
       (let [index-name "people_with_locations"
             opts {:context {:location {:lat 90.23 :lon 90.56}}}
             res (doc/suggest conn index-name :fuzzy "es" opts)]
-        (is (= true (map? (:hits res))))
+        (is (map? (:hits res)))
         (is (= 1 (-> res :hits :options count)))
         (is (= "esjack" (-> res :hits :options first :text)))))))


### PR DESCRIPTION
Using "true" in the tests explicitly is not needed. Assertions will
work without it just fine.