### PR TITLE
Allow overriding :throw-exceptions option.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ GitHub issue: [#193](https://github.com/clojurewerkz/elastisch/pull/193).
 
 Contributed by @dspiteself.
 
+### Allow overriding clj-http's :throw-exceptions option
+
+Options passed to elastisch.rest/connect can now include `:throw-exceptions true`, causing HTTP errors to throw exceptions.
+
+Contributed by @loganmhb.
 
 
 ## Changes between Elastisch 2.1.x and 2.2.0 (Jan 3rd, 2016)

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -38,46 +38,68 @@
 
 (defn post-string
   [^Connection conn ^String uri {:keys [body] :as options}]
-  (json/decode (:body (http/post uri (merge (.http-opts conn) options
-                                            {:accept :json :body body}))) true))
+  (json/decode (:body (http/post uri (merge (.http-opts conn)
+                                            options
+                                            {:accept :json :body body})))
+               true))
 
 (defn post
   ([^Connection conn ^String uri]
-     (post conn uri {}))
+   (post conn uri {}))
   ([^Connection conn ^String uri {:keys [body] :as options}]
-     (json/decode (:body (http/post uri (merge (.http-opts conn) options
-                                               {:accept :json :body (json/encode body)}))) true)))
+   (json/decode (:body (http/post uri (merge (.http-opts conn)
+                                             options
+                                             {:accept :json :body (json/encode body)})))
+                true)))
 
 (defn put
   [^Connection conn ^String uri {:keys [body] :as options}]
-  (json/decode (:body (http/put uri (merge (.http-opts conn) options
-                                           {:accept :json :body (json/encode body) :throw-exceptions throw-exceptions}))) true))
+  (json/decode (:body (http/put uri (merge {:throw-exceptions throw-exceptions}
+                                           (.http-opts conn)
+                                           options
+                                           {:accept :json :body (json/encode body)})))
+               true))
 
 (defn get
   ([^Connection conn ^String uri]
-     (json/decode (:body (http/get uri (merge (.http-opts conn) {:accept :json :throw-exceptions throw-exceptions}))) true))
+   (json/decode (:body (http/get uri (merge {:throw-exceptions throw-exceptions}
+                                            (.http-opts conn)
+                                            {:accept :json})))
+                true))
   ([^Connection conn ^String uri options]
-     (json/decode (:body (http/get uri (merge (.http-opts conn) options
-                                              {:accept :json :throw-exceptions throw-exceptions}))) true)))
+   (json/decode (:body (http/get uri (merge {:throw-exceptions throw-exceptions}
+                                            (.http-opts conn)
+                                            options
+                                            {:accept :json})))
+                true)))
 
 (defn ^:private get*
   "Like get but takes no connection"
   ([^String uri]
-     (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions})) true))
+   (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions}))
+                true))
   ([^String uri options]
-     (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions})) true)))
+   (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions}))
+                true)))
 
 (defn head
   [^Connection conn ^String uri]
-  (http/head uri (merge (.http-opts conn) {:accept :json :throw-exceptions throw-exceptions})))
+  (http/head uri (merge {:throw-exceptions throw-exceptions}
+                        (.http-opts conn)
+                        {:accept :json})))
 
 (defn delete
   ([^Connection conn ^String uri]
-     (json/decode (:body (http/delete uri (merge (.http-opts conn)
-                                                 {:accept :json :throw-exceptions throw-exceptions}))) true))
+   (json/decode (:body (http/delete uri (merge {:throw-exceptions throw-exceptions}
+                                               (.http-opts conn)
+                                               {:accept :json})))
+                true))
   ([^Connection conn ^String uri {:keys [body] :as options}]
-     (json/decode (:body (http/delete uri (merge (.http-opts conn) options
-                                                 {:accept :json :body (json/encode body) :throw-exceptions throw-exceptions}))) true)))
+   (json/decode (:body (http/delete uri (merge {:throw-exceptions throw-exceptions}
+                                               (.http-opts conn)
+                                               options
+                                               {:accept :json :body (json/encode body)})))
+                true)))
 
 
 (defn url-with-path


### PR DESCRIPTION
Merging {:throw-exceptions false} prior to user-supplied options for
clj-http instead of afterwards allows the user to decide whether
elastisch calls with throw exceptions or not.