### PR TITLE
Add search templates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1600,3 +1600,18 @@ with the same id.
 ### Leiningen 2
 
 Elastisch now uses [Leiningen 2](https://github.com/technomancy/leiningen/wiki/Upgrading).
+
+### elastisch.conversion
+Added template and params values to ->search-request to allow searching by
+search template
+
+### elastisch.native.document
+Added helper functions for search templates that are alias of existing
+functions
+  create-search-template
+  delete-search-template
+  put-search-template
+  get-search-template
+Each of these is vardic and references index ".scripts" type "mustache" by
+default
+Contributed by @KeeganMyers

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
+### Added support for search templates
+  `clojurewerks.elastisch.native.conversion/->search-request` now accepts
+  :template and :params arguments for use with search templates
+  `clojurewerks.elastish.native.document/create-search-template`,
+  `clojurewerks.elastish.native.document/delete-search-template`,
+  `clojurewerks.elastish.native.document/put-search-template`,
+  `clojurewerks.elastish.native.document/get-search-template`,
+   Added to simplify CRUD operations on search templates. Each is a vardic
+   function that will interface with the ".scripts" index and "mustache" type
+   by default. Users can override the type parameter if they would like to write
+   scripts in a language other than mustache.
+
+Contributed by @KeeganMyers
+
 ### Correctly Pass Field List to the Native Client
 
 GitHub issue: [#193](https://github.com/clojurewerkz/elastisch/pull/193).
@@ -1600,18 +1614,3 @@ with the same id.
 ### Leiningen 2
 
 Elastisch now uses [Leiningen 2](https://github.com/technomancy/leiningen/wiki/Upgrading).
-
-### elastisch.conversion
-Added template and params values to ->search-request to allow searching by
-search template
-
-### elastisch.native.document
-Added helper functions for search templates that are alias of existing
-functions
-  create-search-template
-  delete-search-template
-  put-search-template
-  get-search-template
-Each of these is vardic and references index ".scripts" type "mustache" by
-default
-Contributed by @KeeganMyers

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -701,6 +701,7 @@
 (defn ^SearchRequest ->search-request
   [index-name mapping-type {:keys [search-type search_type scroll routing
                                    preference query facets aggregations from size timeout
+                                   template params
                                    post-filter filter min-score version fields sort stats _source
                                    highlight] :as options}]
   (let [r                       (SearchRequest.)
@@ -752,7 +753,11 @@
       (.routing r ^String routing))
     (when scroll
       (.scroll r ^String scroll))
-
+    (when template
+      (.templateName r ^String (:id template))
+      (.templateType r ^org.elasticsearch.script.ScriptService$ScriptType org.elasticsearch.script.ScriptService$ScriptType/INDEXED))
+    (when params
+      (.templateParams r ^Map (wlk/stringify-keys params)))
     r))
 
 (defn ^MultiSearchRequest ->multi-search-request

--- a/src/clojurewerkz/elastisch/native/document.clj
+++ b/src/clojurewerkz/elastisch/native/document.clj
@@ -70,6 +70,17 @@
                                                           (merge opts {:op-type "create"})))]
        (cnv/index-response->map (.actionGet res)))))
 
+
+   (defn create-search-template
+    "Adds a search template to the .scripts index the template should be
+     a map of the form:
+     {:template {:filter {:term {:name \"{{name}}\"}}}}
+    templates can be referenced at search time using their given id"
+    ([^Client conn ^String id ^Map document]
+      (create-search-template conn "mustache" id document))
+    ([^Client conn ^String languege ^String id ^Map document]
+      (create conn ".scripts" languege document :id id)))
+
 (defn async-create
   "Adds document to the search index and returns a future without waiting
     for the response. Takes exactly the same arguments as create."
@@ -94,6 +105,15 @@
                                                document
                                                (merge opts {:id id :op-type "index"})))]
        (cnv/index-response->map (.actionGet res)))))
+
+(defn put-search-template
+  "Updates a search template in the .scripts index. Templates are expressed
+   as maps similar to:
+   {:template {:filter {:term {:name \"{{name}}\"}}}}"
+  ([^Client connid ^String id ^Map document]
+    (put-search-template connid "mustache" id document))
+  ([^Client connid ^String language  ^String id ^Map document]
+    (put connid ".scripts" language id document)))
 
 (defn async-put
   "Creates or updates a document in the search index using the provided document id
@@ -158,6 +178,17 @@
      (cnv/update-response->map (.actionGet res)))))
 
 
+
+(defn upsert-search-template
+  "Add or insert a search template. The expected doc should
+   be similar to:
+    {:template {:filter {:term {:name \"{{name}}\"}}}}
+  The search template will be placed into the .scripts directory."
+  ([^Client conn ^String id ^Map doc]
+  (upsert conn ".scripts" "mustache" id doc))
+  ([^Client conn ^String id ^String lang ^Map doc]
+  (upsert conn ".scripts" lang id doc)))
+
 (defn get
   "Fetches and returns a document by id or nil if it does not exist.
    Waits for response.
@@ -183,6 +214,12 @@
            ^GetResponse res (.actionGet ft)]
        (when (.isExists res)
          (cnv/get-response->map (.actionGet ft))))))
+
+(defn get-search-template
+([^Client conn ^String id]
+  (get-search-template conn "mustache" id))
+([^Client conn ^String languege ^String id]
+  (get conn ".scripts" languege id)))
 
 (defn async-get
   "Fetches and returns a document by id or nil if it does not exist.
@@ -255,6 +292,13 @@
      (let [ft                  (es/delete conn (cnv/->delete-request index mapping-type id (ar/->opts args)))
            ^DeleteResponse res (.actionGet ft)]
        (cnv/delete-response->map res))))
+
+(defn delete-search-template
+"Removes a search template from .scripts index"
+([^Client conn ^String id]
+  (delete-search-template conn "mustache" id))
+([^Client conn ^String languege ^String id]
+  (delete conn ".scripts" languege id)))
 
 (defn delete-by-query
   "Performs a delete-by-query operation.

--- a/src/clojurewerkz/elastisch/native/document.clj
+++ b/src/clojurewerkz/elastisch/native/document.clj
@@ -179,16 +179,6 @@
 
 
 
-(defn upsert-search-template
-  "Add or insert a search template. The expected doc should
-   be similar to:
-    {:template {:filter {:term {:name \"{{name}}\"}}}}
-  The search template will be placed into the .scripts directory."
-  ([^Client conn ^String id ^Map doc]
-  (upsert conn ".scripts" "mustache" id doc))
-  ([^Client conn ^String id ^String lang ^Map doc]
-  (upsert conn ".scripts" lang id doc)))
-
 (defn get
   "Fetches and returns a document by id or nil if it does not exist.
    Waits for response.

--- a/test/clojurewerkz/elastisch/fixtures.clj
+++ b/test/clojurewerkz/elastisch/fixtures.clj
@@ -224,6 +224,18 @@
                :state   "Moscow"
                :city    "Moscow"}})
 
+(def test-template1
+    {:template 
+      {:filter 
+        {:term 
+          {:username "{{username}}"}}}})
+
+
+(def test-template2
+    {:template 
+      {:filter 
+        {:term 
+          {:username "{{username}}"}} :_source ["username"]}})
 
 (def tweet2
   {:username  "ifesdjeen"

--- a/test/clojurewerkz/elastisch/native_api/delete_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/delete_test.clj
@@ -29,6 +29,15 @@
     (is (found? (doc/delete conn index-name mapping-type id)))
     (is (not (doc/present? conn index-name mapping-type id)))))
 
+(deftest ^{:native true} test-delte-search-template
+  (doc/create-search-template conn "test-template1" fx/test-template1)
+  (let [{:keys  [found _index _type]} (doc/delete-search-template conn "test-template1")
+        result (doc/get-search-template conn "test-template1")]
+    (is (= found true))
+    (is (= _index ".scripts"))
+    (is (= _type "mustache"))
+    (is (nil? result))))
+
 (deftest ^{:native true} test-delete-by-query-with-a-term-query-and-mapping
   (let [index-name   "people"
         mapping-type "person"]

--- a/test/clojurewerkz/elastisch/native_api/get_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/get_test.clj
@@ -62,6 +62,15 @@
                      (update-in [:location] #(dissoc % :country)))
                  (:_source (doc/get conn index-name mapping-type id {:_source {:exclude ["username" "location.country"]}})))))))
 
+  (deftest ^{:native true} test-get-search-template
+   (doc/put-search-template conn "test-template1" fx/test-template1)
+   (let [{:keys [exists _id empty? index _type source]} (doc/get-search-template conn "test-template1")]
+      (is exists)
+      (is (= _id "test-template1"))
+      (is (= empty? false))
+      (is (= _type "mustache" ))
+      (is (= source  fx/test-template1))))
+
   (deftest ^{:native true} multi-get-test
     (doc/put conn index-name mapping-type "1" fx/person-jack)
     (doc/put conn index-name mapping-type "2" fx/person-mary)

--- a/test/clojurewerkz/elastisch/native_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_test.clj
@@ -132,4 +132,22 @@
                                               :sort    (q/sort "surname"
                                                                {:order "asc"
                                                                 :ignore-unmapped true})))]
-      (is (= 4 (count hits))))))
+      (is (= 4 (count hits)))))
+
+  (deftest ^{:native true} search-using-template-with-results
+  (doc/create-search-template conn "test-template1" fx/test-template1)
+  (doc/create conn "tweets" "tweet" fx/tweet1)
+    (let [result (map :source (hits-from (doc/search conn "tweets" "tweet"
+                             :template {:id "test-template1"}
+                             :params {:username "clojurewerkz"})))]
+  (is (= 1 (count result)))))
+
+
+
+  (deftest ^{:native true} search-using-template-without-results
+  (doc/create-search-template conn "test-template1" fx/test-template1)
+  (doc/create conn "tweets" "tweet" fx/tweet1)
+    (let [result (map :source (hits-from (doc/search conn "tweets" "tweet"
+                             :template {:id "test-template1"}
+                             :params {:username "returns nothing"})))]
+  (is (empty?  result)))))

--- a/test/clojurewerkz/elastisch/native_api/update_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/update_test.clj
@@ -85,6 +85,23 @@
           (is (= "brilliant1" (get-in updated [:_source :biography])))
           (is (= "Sweden" (get-in updated [:_source :country])))))))
 
+  (deftest ^{:native true} create-search-template
+    (let [{:keys [index id _type]}
+          (doc/create-search-template conn "test-template1" fx/test-template1)]
+          (is (= index ".scripts"))
+          (is (= id "test-template1"))
+          (is (= _type "mustache"))))
+
+  (deftest ^{:native true} update-search-template
+      (doc/create-search-template conn "test-template1" fx/test-template1)
+      (doc/put-search-template conn "test-template1" fx/test-template2)
+    (let [{:keys [index id _type source]}
+          (doc/get-search-template conn "test-template1")]
+          (is (= index ".scripts"))
+          (is (= id "test-template1"))
+          (is (= _type "mustache"))
+          (is (= source fx/test-template2))))
+
   (deftest ^{:version-dependent true} update-with-script
     (let [index-name "people"
           index-type "person"


### PR DESCRIPTION
In relation to issue #201 I opened recently, I have updated the search-request function to allow users to search using a template as follows

(doc/search index type :template {:id template-id} :params {:param1 value1})

This should be in keeping with the API guides for elasticsearch 1.7. Also I added some helper methods to simplify CRUD operations for the search templates. Let me know if you have any concerns.