### PR TITLE
Allow default HTTP options to be overridden (in `master` branch)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,14 +1,15 @@
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
-### Allow overriding *any* clj-http option
+### Make it Possible to Override *any* clj-http Option
 
 The default clj-http options that Elastisch sets can now be overridden in two ways:
-- on a per-connection basis by passing the options to `clojurewerkz.elastisch.rest/connect`;
-- and per-invocation by passing the options as arguments to individual function calls.
+
+ * on a per-connection basis by passing the options to `clojurewerkz.elastisch.rest/connect`
+ * and per-invocation by passing the options as arguments to individual function calls
 
 This was achieved by changing the order in which the options-maps are merged.
 
-GitHub Pull Request: <https://github.com/clojurewerkz/elastisch/pull/200>
+GitHub issue: [clojurewerkz/elastisch#200](https://github.com/clojurewerkz/elastisch/pull/200).
 
 Contributed by [@MerelyAPseudonym](https://github.com/MerelyAPseudonym).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
+### Allow overriding *any* clj-http option
+
+The default clj-http options that Elastisch sets can now be overridden in two ways:
+- on a per-connection basis by passing the options to `clojurewerkz.elastisch.rest/connect`;
+- and per-invocation by passing the options as arguments to individual function calls.
+
+This was achieved by changing the order in which the options-maps are merged.
+
+GitHub Pull Request: <https://github.com/clojurewerkz/elastisch/pull/200>
+
+Contributed by [@MerelyAPseudonym](https://github.com/MerelyAPseudonym).
+
 ### Added support for search templates
   `clojurewerks.elastisch.native.conversion/->search-request` now accepts
   :template and :params arguments for use with search templates

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -79,7 +79,8 @@
    (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions}))
                 true))
   ([^String uri options]
-   (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions}))
+   (json/decode (:body (http/get uri (merge options
+                                            {:accept :json :throw-exceptions throw-exceptions})))
                 true)))
 
 (defn head

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -38,39 +38,39 @@
 
 (defn post-string
   [^Connection conn ^String uri {:keys [body] :as options}]
-  (json/decode (:body (http/post uri (merge (.http-opts conn)
+  (json/decode (:body (http/post uri (merge {:accept :json}
+                                            (.http-opts conn)
                                             options
-                                            {:accept :json :body body})))
+                                            {:body body})))
                true))
 
 (defn post
   ([^Connection conn ^String uri]
    (post conn uri {}))
   ([^Connection conn ^String uri {:keys [body] :as options}]
-   (json/decode (:body (http/post uri (merge (.http-opts conn)
+   (json/decode (:body (http/post uri (merge {:accept :json}
+                                             (.http-opts conn)
                                              options
-                                             {:accept :json :body (json/encode body)})))
+                                             {:body (json/encode body)})))
                 true)))
 
 (defn put
   [^Connection conn ^String uri {:keys [body] :as options}]
-  (json/decode (:body (http/put uri (merge {:throw-exceptions throw-exceptions}
+  (json/decode (:body (http/put uri (merge {:accept :json :throw-exceptions throw-exceptions}
                                            (.http-opts conn)
                                            options
-                                           {:accept :json :body (json/encode body)})))
+                                           {:body (json/encode body)})))
                true))
 
 (defn get
   ([^Connection conn ^String uri]
-   (json/decode (:body (http/get uri (merge {:throw-exceptions throw-exceptions}
-                                            (.http-opts conn)
-                                            {:accept :json})))
+   (json/decode (:body (http/get uri (merge {:accept :json :throw-exceptions throw-exceptions}
+                                            (.http-opts conn))))
                 true))
   ([^Connection conn ^String uri options]
-   (json/decode (:body (http/get uri (merge {:throw-exceptions throw-exceptions}
+   (json/decode (:body (http/get uri (merge {:accept :json :throw-exceptions throw-exceptions}
                                             (.http-opts conn)
-                                            options
-                                            {:accept :json})))
+                                            options)))
                 true)))
 
 (defn ^:private get*
@@ -79,27 +79,25 @@
    (json/decode (:body (http/get uri {:accept :json :throw-exceptions throw-exceptions}))
                 true))
   ([^String uri options]
-   (json/decode (:body (http/get uri (merge options
-                                            {:accept :json :throw-exceptions throw-exceptions})))
+   (json/decode (:body (http/get uri (merge {:accept :json :throw-exceptions throw-exceptions}
+                                            options)))
                 true)))
 
 (defn head
   [^Connection conn ^String uri]
-  (http/head uri (merge {:throw-exceptions throw-exceptions}
-                        (.http-opts conn)
-                        {:accept :json})))
+  (http/head uri (merge {:accept :json :throw-exceptions throw-exceptions}
+                        (.http-opts conn))))
 
 (defn delete
   ([^Connection conn ^String uri]
-   (json/decode (:body (http/delete uri (merge {:throw-exceptions throw-exceptions}
-                                               (.http-opts conn)
-                                               {:accept :json})))
+   (json/decode (:body (http/delete uri (merge {:accept :json :throw-exceptions throw-exceptions}
+                                               (.http-opts conn))))
                 true))
   ([^Connection conn ^String uri {:keys [body] :as options}]
-   (json/decode (:body (http/delete uri (merge {:throw-exceptions throw-exceptions}
+   (json/decode (:body (http/delete uri (merge {:accept :json :throw-exceptions throw-exceptions}
                                                (.http-opts conn)
                                                options
-                                               {:accept :json :body (json/encode body)})))
+                                               {:body (json/encode body)})))
                 true)))
 
 

--- a/test/clojurewerkz/elastisch/rest_api/document_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/document_test.clj
@@ -1,0 +1,33 @@
+(ns clojurewerkz.elastisch.rest-api.document-test
+  (:require [clojurewerkz.elastisch.rest :as es]
+            [clojurewerkz.elastisch.rest.document :as es.document]
+            clj-http.core
+            [clojure.test :refer :all])
+  (:import java.io.ByteArrayInputStream
+           clojure.lang.ExceptionInfo))
+
+(deftest ^:rest test-http-options-overridability
+  (let [default-conn (es/connect)
+        throwing-conn (es/connect "http://localhost:9200"
+                                  {:throw-exceptions true})
+        no-throwing-conn (es/connect "http://localhost:9200"
+                                     {:throw-exceptions false})
+        index "arbitrary_index"
+        mapping "arbitrary_mapping"
+        id "arbitrary_id"
+        doc {"arbitrary_attribute" "arbitrary value"}]
+    (with-redefs [clj-http.core/request (constantly {:status 400
+                                                     :body (.getBytes "{\"error\": \"This is an example exception.\", \"status\": 400}"
+                                                                      "UTF-8")})]
+      (testing "that the functions that default to swallowing exceptions can be configured to actually throw them"
+        (is (= (es.document/put default-conn index mapping id doc)
+               {:error "This is an example exception.", :status 400}))
+        (is (thrown-with-msg? ExceptionInfo
+                              #"clj-http: status 400"
+                              (es.document/put throwing-conn index mapping id doc))))
+      (testing "that the functions that default to throwing exceptions can be configured to swallow them"
+        (is (thrown-with-msg? ExceptionInfo
+                              #"clj-http: status 400"
+                              (es.document/create default-conn index mapping doc :id id)))
+        (is (= (es.document/create no-throwing-conn index mapping doc :id id)
+               {:error "This is an example exception.", :status 400}))))))


### PR DESCRIPTION
As requested by https://github.com/clojurewerkz/elastisch/pull/200#issuecomment-196584305, I've cherry-picked the changes onto `master`.