### PR TITLE
upgraded ES to 2.3.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,6 @@ manually tweak them.
 docker run -d -p 9200:9200 -p 9300:9300 --name="elastisch-test"  \
 	-v "$PWD/resources/config":/usr/share/elasticsearch/config   \
 	elasticsearch:2.0.2 \ 
-	-Des.node.name="es-test" -Des.network.bind_host=0.0.0.0
 ```
 
 * set environment variables

--- a/project.clj
+++ b/project.clj
@@ -7,11 +7,12 @@
                  [clj-http              "2.0.1" :exclusions [org.clojure/clojure]]
                  [clojurewerkz/support  "1.1.0" :exclusions [com.google.guava/guava]]
                  ;; used by the native client
-                 [org.elasticsearch/elasticsearch "2.0.2"]]
+                 [org.elasticsearch/elasticsearch "2.3.1"]]
   :min-lein-version "2.5.1"
   :profiles     {:dev {:resource-paths ["test/resources"]
                        :dependencies [[clj-time "0.11.0" :exclusions [org.clojure/clojure]]
-                                      [org.elasticsearch/elasticsearch "2.0.0" :classifier "tests"]]
+                                      ;[org.elasticsearch/elasticsearch "2.3.1" :classifier "tests"]
+                                      ]
                        :plugins [[lein-codox      "0.9.0"]
                                  [jonase/eastwood "0.2.3"]]
                        :codox {:source-paths ["src"]}}

--- a/project.clj
+++ b/project.clj
@@ -10,9 +10,7 @@
                  [org.elasticsearch/elasticsearch "2.3.1"]]
   :min-lein-version "2.5.1"
   :profiles     {:dev {:resource-paths ["test/resources"]
-                       :dependencies [[clj-time "0.11.0" :exclusions [org.clojure/clojure]]
-                                      ;[org.elasticsearch/elasticsearch "2.3.1" :classifier "tests"]
-                                      ]
+                       :dependencies [[clj-time "0.11.0" :exclusions [org.clojure/clojure]]]
                        :plugins [[lein-codox      "0.9.0"]
                                  [jonase/eastwood "0.2.3"]]
                        :codox {:source-paths ["src"]}}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :description "Minimalistic fully featured well documented Clojure ElasticSearch client"
   :license {:name "Eclipse Public License"}
   :dependencies [[org.clojure/clojure   "1.7.0"]
-                 [cheshire              "5.5.0"]
+                 [cheshire              "5.6.1"]
                  [clj-http              "2.0.1" :exclusions [org.clojure/clojure]]
                  [clojurewerkz/support  "1.1.0" :exclusions [com.google.guava/guava]]
                  ;; used by the native client

--- a/resources/config/elasticsearch.yml
+++ b/resources/config/elasticsearch.yml
@@ -5,3 +5,6 @@ node:
 
 script.inline: on
 script.indexed: on
+
+network:
+  bind_host: "0.0.0.0"

--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -169,10 +169,10 @@
   (-> ^Client conn .admin .indices (.close req)))
 
 ;;DEPRECATED in 2.1- replaced with forceMerge
-(defn ^ActionFuture admin-optimize-index
+(defn ^ActionFuture admin-merge-index
   "Executes a optimize index request"
   [^Client conn ^ForceMergeRequest req]
-  (-> ^Client conn .admin .indices (.optimize req)))
+  (-> ^Client conn .admin .indices (.forceMerge req)))
 
 (defn ^ActionFuture admin-flush-index
   "Executes a flush index request"

--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -38,7 +38,8 @@
            org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest
            org.elasticsearch.action.admin.indices.open.OpenIndexRequest
            org.elasticsearch.action.admin.indices.close.CloseIndexRequest
-           org.elasticsearch.action.admin.indices.optimize.OptimizeRequest
+           [org.elasticsearch.action.admin.indices.forcemerge ForceMergeAction ForceMergeRequest] 
+
            org.elasticsearch.action.admin.indices.flush.FlushRequest
            org.elasticsearch.action.admin.indices.refresh.RefreshRequest
            org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest
@@ -167,9 +168,10 @@
   [^Client conn ^CloseIndexRequest req]
   (-> ^Client conn .admin .indices (.close req)))
 
+;;DEPRECATED in 2.1- replaced with forceMerge
 (defn ^ActionFuture admin-optimize-index
   "Executes a optimize index request"
-  [^Client conn ^OptimizeRequest req]
+  [^Client conn ^ForceMergeRequest req]
   (-> ^Client conn .admin .indices (.optimize req)))
 
 (defn ^ActionFuture admin-flush-index

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -78,7 +78,8 @@
            org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse
            org.elasticsearch.action.admin.indices.open.OpenIndexRequest
            org.elasticsearch.action.admin.indices.close.CloseIndexRequest
-           org.elasticsearch.action.admin.indices.optimize.OptimizeRequest
+           [org.elasticsearch.action.admin.indices.forcemerge ForceMergeAction ForceMergeRequest] 
+           ;[org.elasticsearch.action.admin.indices.optimize ForceMergeAction]
            org.elasticsearch.action.admin.indices.flush.FlushRequest
            org.elasticsearch.action.admin.indices.refresh.RefreshRequest
            org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest
@@ -1136,10 +1137,10 @@
   [index-name]
   (CloseIndexRequest. (->string-array index-name)))
 
-(defn ^OptimizeRequest ->optimize-index-request
+(defn ^ForceMergeRequest ->optimize-index-request
   [index-name {:keys [max-num-segments only-expunge-deletes flush]}]
   (let [ary (->string-array index-name)
-        r   (OptimizeRequest. ary)]
+        r   (ForceMergeRequest. ary)]
     (when max-num-segments
       (.maxNumSegments r ^{:tag "int"} max-num-segments))
     (when only-expunge-deletes

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -79,7 +79,6 @@
            org.elasticsearch.action.admin.indices.open.OpenIndexRequest
            org.elasticsearch.action.admin.indices.close.CloseIndexRequest
            [org.elasticsearch.action.admin.indices.forcemerge ForceMergeAction ForceMergeRequest] 
-           ;[org.elasticsearch.action.admin.indices.optimize ForceMergeAction]
            org.elasticsearch.action.admin.indices.flush.FlushRequest
            org.elasticsearch.action.admin.indices.refresh.RefreshRequest
            org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1136,7 +1136,7 @@
   [index-name]
   (CloseIndexRequest. (->string-array index-name)))
 
-(defn ^ForceMergeRequest ->optimize-index-request
+(defn ^ForceMergeRequest ->force-merge-request
   [index-name {:keys [max-num-segments only-expunge-deletes flush]}]
   (let [ary (->string-array index-name)
         r   (ForceMergeRequest. ary)]

--- a/src/clojurewerkz/elastisch/native/index.clj
+++ b/src/clojurewerkz/elastisch/native/index.clj
@@ -152,12 +152,13 @@
         ^CloseIndexResponse res (.actionGet ft)]
     {:ok (.isAcknowledged res) :acknowledged (.isAcknowledged res)}))
 
-;;DEPRECATED - replaced with forcemerge
-(defn optimize
+(defn force-merge
   "Optimizes an index or multiple indices"
   [^Client conn index-name & args]
-  (let [opts                  (ar/->opts args)
-        ft                    (es/admin-optimize-index conn (cnv/->optimize-index-request index-name opts))
+  (let [opts (ar/->opts args)
+        ft   (es/admin-merge-index
+               conn
+               (cnv/->force-merge-request index-name opts))
         ^ForceMergeResponse res (.actionGet ft)]
     (cnv/broadcast-operation-response->map res)))
 

--- a/src/clojurewerkz/elastisch/native/index.clj
+++ b/src/clojurewerkz/elastisch/native/index.clj
@@ -27,7 +27,8 @@
            org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse
            org.elasticsearch.action.admin.indices.open.OpenIndexResponse
            org.elasticsearch.action.admin.indices.close.CloseIndexResponse
-           org.elasticsearch.action.admin.indices.optimize.OptimizeResponse
+           [org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse]
+           ;org.elasticsearch.action.admin.indices.optimize.OptimizeResponse
            org.elasticsearch.action.admin.indices.flush.FlushResponse
            org.elasticsearch.action.admin.indices.refresh.RefreshResponse
            org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse
@@ -151,12 +152,13 @@
         ^CloseIndexResponse res (.actionGet ft)]
     {:ok (.isAcknowledged res) :acknowledged (.isAcknowledged res)}))
 
+;;DEPRECATED - replaced with forcemerge
 (defn optimize
   "Optimizes an index or multiple indices"
   [^Client conn index-name & args]
   (let [opts                  (ar/->opts args)
         ft                    (es/admin-optimize-index conn (cnv/->optimize-index-request index-name opts))
-        ^OptimizeResponse res (.actionGet ft)]
+        ^ForceMergeResponse res (.actionGet ft)]
     (cnv/broadcast-operation-response->map res)))
 
 (defn flush

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -65,10 +65,10 @@
           _         (idx/create conn index :mappings fx/people-mapping)]
       (is (idx/update-settings conn index settings))))
 
-  (deftest ^{:indexing true :native true} test-optimize-index
+  (deftest ^{:indexing true :native true} test-force-merge-index
     (let [index     "people"
           _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/optimize conn index :only_expunge_deletes 1)]
+          response  (idx/force-merge conn index :only_expunge_deletes 1)]
       (is (broadcast-operation-response? response))))
 
   (deftest ^{:indexing true :native true} test-flush-index


### PR DESCRIPTION
Hi,

i updated ES in project.clj from 2.0.2 to 2.3.1 and it passes all the tests.

My pull-request includes:

* upgraded cheshire from 5.5 to [5.6.1](https://www.versioneye.com/clojure/cheshire:cheshire/5.6.1)
* simplified Docker example in contributions.md as those ES vars could move to the `settings.yml` file
* replaced deprecated index `optimize` with `force-merge` as it's deprecated since 2.1. [source](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/breaking_21_index_apis.html) 