### PR TITLE
Prefer option-maps over “kwargs”

### DIFF
--- a/src/clojurewerkz/elastisch/arguments.clj
+++ b/src/clojurewerkz/elastisch/arguments.clj
@@ -1,9 +1,0 @@
-(ns clojurewerkz.elastisch.arguments)
-
-(defn ->opts
-  "Coerces arguments to a map"
-  [args]
-  (let [x (first args)]
-    (if (map? x)
-      x
-      (apply array-map args))))

--- a/src/clojurewerkz/elastisch/native.clj
+++ b/src/clojurewerkz/elastisch/native.clj
@@ -253,12 +253,13 @@
        tc)))
 
 (defn ^Node build-local-node
-  [settings & {:keys [client] :or {client true}}]
-  (let [is (cnv/->settings settings)
-        nb (.. NodeBuilder nodeBuilder
-               (settings is)
-               (client client))]
-    (.build ^NodeBuilder nb)))
+  ([settings] (build-local-node settings nil))
+  ([settings {:keys [client], :or {client true}}]
+   (let [is (cnv/->settings settings)
+         nb (.. NodeBuilder nodeBuilder
+                (settings is)
+                (client client))]
+     (.build ^NodeBuilder nb))))
 
 (defn ^Node start-local-node
   [^Node node]

--- a/src/clojurewerkz/elastisch/native/admin.clj
+++ b/src/clojurewerkz/elastisch/native/admin.clj
@@ -14,28 +14,27 @@
 
 (ns clojurewerkz.elastisch.native.admin
   (:require [clojurewerkz.elastisch.native :as es]
-            [clojurewerkz.elastisch.native.conversion :as cnv]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojurewerkz.elastisch.native.conversion :as cnv])
   (:import org.elasticsearch.client.Client
            org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse
            org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
            org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotResponse))
 
 (defn register-snapshot-repository
-  [^Client conn ^String name & args]
-  (let [opts                       (ar/->opts args)
-        ft                         (es/admin-put-repository conn (cnv/->put-repository-request name opts))
-        ^PutRepositoryResponse res (.actionGet ft)]
-    (cnv/acknowledged-response->map res)))
+  ([^Client conn ^String name] (register-snapshot-repository conn name nil))
+  ([^Client conn ^String name opts]
+   (let [ft                         (es/admin-put-repository conn (cnv/->put-repository-request name opts))
+         ^PutRepositoryResponse res (.actionGet ft)]
+     (cnv/acknowledged-response->map res))))
 
 (defn take-snapshot
   "Takes a snapshot"
-  [^Client conn ^String repository ^String snapshot & args]
-  (let [opts                         (ar/->opts args)
-        ft                           (es/admin-create-snapshot conn (cnv/->create-snapshot-request repository snapshot opts))
-        ^CreateSnapshotResponse res (.actionGet ft)]
-    ;; TODO: actually calculate this using RestStatus
-    {:accepted true}))
+  ([^Client conn ^String repository ^String snapshot] (take-snapshot conn repository snapshot nil))
+  ([^Client conn ^String repository ^String snapshot opts]
+   (let [ft                           (es/admin-create-snapshot conn (cnv/->create-snapshot-request repository snapshot opts))
+         ^CreateSnapshotResponse res (.actionGet ft)]
+     ;; TODO: actually calculate this using RestStatus
+     {:accepted true})))
 
 (defn delete-snapshot
   "Deletes a snapshot"

--- a/src/clojurewerkz/elastisch/native/multi.clj
+++ b/src/clojurewerkz/elastisch/native/multi.clj
@@ -14,30 +14,29 @@
 
 (ns clojurewerkz.elastisch.native.multi
   (:require [clojurewerkz.elastisch.native :as es]
-            [clojurewerkz.elastisch.native.conversion :as cnv]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojurewerkz.elastisch.native.conversion :as cnv])
   (:import org.elasticsearch.client.Client))
 
 (defn search
   "Performs multi search"
-  [^Client conn queries & params]
-  (let [opts (ar/->opts params)
-        res  (es/multi-search conn (cnv/->multi-search-request conn queries opts))]
-    (cnv/multi-search-response->seq (.actionGet res))))
+  ([^Client conn queries] (search conn queries nil))
+  ([^Client conn queries opts]
+   (let [res  (es/multi-search conn (cnv/->multi-search-request conn queries opts))]
+     (cnv/multi-search-response->seq (.actionGet res)))))
 
 (defn search-with-index
   "Performs multi search defaulting to the index specified"
-  [^Client conn index queries & params]
-  (let [opts (ar/->opts params)
-        res  (es/multi-search conn (cnv/->multi-search-request conn index queries opts))]
-    (cnv/multi-search-response->seq (.actionGet res))))
+  ([^Client conn index queries] (search-with-index conn index queries nil))
+  ([^Client conn index queries opts]
+   (let [res (es/multi-search conn (cnv/->multi-search-request conn index queries opts))]
+     (cnv/multi-search-response->seq (.actionGet res)))))
 
 (defn search-with-index-and-type
   "Performs multi search defaulting to the index and type specified"
-  [^Client conn index mapping-type queries & params]
-  (let [opts (ar/->opts params)
-        res  (es/multi-search conn (cnv/->multi-search-request conn
-                                                               index
-                                                               mapping-type
-                                                               queries opts))]
-    (cnv/multi-search-response->seq (.actionGet res))))
+  ([^Client conn index mapping-type queries] (search-with-index-and-type conn index mapping-type queries nil))
+  ([^Client conn index mapping-type queries opts]
+   (let [res  (es/multi-search conn (cnv/->multi-search-request conn
+                                                                index
+                                                                mapping-type
+                                                                queries opts))]
+     (cnv/multi-search-response->seq (.actionGet res)))))

--- a/src/clojurewerkz/elastisch/native/percolation.clj
+++ b/src/clojurewerkz/elastisch/native/percolation.clj
@@ -15,8 +15,7 @@
 (ns clojurewerkz.elastisch.native.percolation
   (:require [clojurewerkz.elastisch.native            :as es]
             [clojurewerkz.elastisch.native.conversion :as cnv]
-            [clojure.walk :as wlk]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojure.walk :as wlk])
   (:import org.elasticsearch.action.index.IndexResponse
            org.elasticsearch.action.delete.DeleteResponse
            org.elasticsearch.action.percolate.PercolateResponse
@@ -31,16 +30,16 @@
 
 (defn register-query
   "Registers a percolator for the given index"
-  [^Client conn index query-name & args]
-  (let [opts                     (ar/->opts args)
-        ^IndexRequestBuilder irb (doto (.prepareIndex ^Client conn
-                                                      index
-                                                      PercolatorService/TYPE_NAME
-                                                      query-name)
-                                   (.setSource ^Map (wlk/stringify-keys opts)))
-        ft                       (.execute irb)
-        ^IndexResponse res       (.actionGet ft)]
-    (merge (cnv/index-response->map res) {:ok true})))
+  ([^Client conn index query-name] (register-query conn index query-name nil))
+  ([^Client conn index query-name opts]
+   (let [^IndexRequestBuilder irb (doto (.prepareIndex ^Client conn
+                                                       index
+                                                       PercolatorService/TYPE_NAME
+                                                       query-name)
+                                    (.setSource ^Map (wlk/stringify-keys opts)))
+         ft                       (.execute irb)
+         ^IndexResponse res       (.actionGet ft)]
+     (merge (cnv/index-response->map res) {:ok true}))))
 
 (defn unregister-query
   "Unregisters a percolator query for the given index"
@@ -54,12 +53,12 @@
 (defn percolate
   "Percolates a document and see which queries match on it. The document is not indexed, just
   matched against the queries you register with [[register-query]]."
-  [^Client conn index mapping-type & args]
-  (let [opts (ar/->opts args)
-        prb  (doto (.preparePercolate ^Client conn)
-               (.setIndices (cnv/->string-array index))
-               (.setDocumentType mapping-type)
-               (.setSource ^Map (wlk/stringify-keys opts)))
-        ft  (.execute prb)
-        ^PercolateResponse res (.actionGet ft)]
-    (cnv/percolate-response->map res)))
+  ([^Client conn index mapping-type] (percolate conn index mapping-type nil))
+  ([^Client conn index mapping-type opts]
+   (let [prb  (doto (.preparePercolate ^Client conn)
+                (.setIndices (cnv/->string-array index))
+                (.setDocumentType mapping-type)
+                (.setSource ^Map (wlk/stringify-keys opts)))
+         ft  (.execute prb)
+         ^PercolateResponse res (.actionGet ft)]
+     (cnv/percolate-response->map res))))

--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -18,52 +18,54 @@
    All functions return maps and are completely optional (but recommended)."
   (:refer-clojure :exclude [range sort])
   (:require [clojure.set :as set]
-            [clojurewerkz.elastisch.escape    :as escape]
-            [clojurewerkz.elastisch.arguments :as ar]))
+            [clojurewerkz.elastisch.escape    :as escape]))
 
 (defn term
   "Term Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-term-query.html"
-  [key values & args]
-  (merge { (if (coll? values) :terms :term) (hash-map key values) }
-         (ar/->opts args)))
+  ([key values] (term key values nil))
+  ([key values opts]
+   (merge { (if (coll? values) :terms :term) (hash-map key values) }
+          opts)))
 
 (defn terms
   "Terms Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html"
-  [key values & args]
-  (apply term key values args))
+  ([key values] (terms key values nil))
+  ([key values opts]
+   (term key values opts)))
 
 (defn range
   "Range Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
-  [key & args]
-  {:range (hash-map key (ar/->opts args)) })
+  [key opts]
+  {:range (hash-map key opts) })
 
 (defn match
   "Match Query, before 0.19.9 known as Text Query.
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-match-query.html"
-  [field query & args]
-  {:match {field (merge {:query query} (ar/->opts args))}})
+  ([field query] (match field query nil))
+  ([field query opts]
+   {:match {field (merge {:query query} opts)}}))
 
 (defn bool
   "Boolean Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html"
-  [& args]
-  {:bool (ar/->opts args)})
+  [opts]
+  {:bool opts})
 
 
 (defn boosting
   "Boosting Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html"
-  [& args]
-  {:boosting (ar/->opts args)})
+  [opts]
+  {:boosting opts})
 
 (defn ids
   "IDs Query
@@ -76,36 +78,36 @@
   "Constant Score Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html"
-  [& args]
-  {:constant_score (ar/->opts args)})
+  [opts]
+  {:constant_score opts})
 
 (defn dis-max
   "Dis Max Query
 
   For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html"
-  [& args]
-  {:dis_max (ar/->opts args)})
+  [opts]
+  {:dis_max opts})
 
 (defn prefix
   "Prefix query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html"
-  [& args]
-  {:prefix (ar/->opts args)})
+  [opts]
+  {:prefix opts})
 
 (defn filtered
   "Filtered query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html"
-  [& args]
-  {:filtered (ar/->opts args)})
+  [opts]
+  {:filtered opts})
 
 (defn fuzzy
   "Fuzzy or Levenshtein (edit distance) query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html"
-  [& args]
-  {:fuzzy (ar/->opts args)})
+  [opts]
+  {:fuzzy opts})
 
 (defn match-all
   "Match All query
@@ -113,15 +115,15 @@
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html"
   ([]
      {:match_all {}})
-  ([& args]
-     {:match_all (ar/->opts args)}))
+  ([opts]
+     {:match_all opts}))
 
 (defn more-like-this
   "MLT (More Like This) query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html"
-  [& args]
-  {:more_like_this (ar/->opts args)})
+  [opts]
+  {:more_like_this opts})
 
 (def mlt more-like-this)
 
@@ -129,9 +131,8 @@
   "Query String query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html"
-  [& args]
-  (let [opts      (ar/->opts args)
-        escape-fn (or (:escape-with opts) escape/escape-query-string-characters)
+  [opts]
+  (let [escape-fn (or (:escape-with opts) escape/escape-query-string-characters)
         options (if-let [query (:query opts)]
                   (assoc opts :query (escape-fn query))
                   opts)]
@@ -141,78 +142,78 @@
   "Span First query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html"
-  [& args]
-  {:span_first (ar/->opts args)})
+  [opts]
+  {:span_first opts})
 
 (defn span-near
   "Span Near query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html"
-  [& args]
-  {:span_near (ar/->opts args)})
+  [opts]
+  {:span_near opts})
 
 (defn span-not
   "Span Not query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html"
-  [& args]
-  {:span_not (ar/->opts args)})
+  [opts]
+  {:span_not opts})
 
 (defn span-or
   "Span Or query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-or-query.html"
-  [& args]
-  {:span_or (ar/->opts args)})
+  [opts]
+  {:span_or opts})
 
 (defn span-term
   "Span Term query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html"
-  [& args]
-  {:span_term (ar/->opts args)})
+  [opts]
+  {:span_term opts})
 
 (defn wildcard
   "Wildcard query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html"
-  [& args]
-  {:wildcard (ar/->opts args)})
+  [opts]
+  {:wildcard opts})
 
 (defn indices
   "Indices query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html"
-  [& args]
-  {:indices (ar/->opts args)})
+  [opts]
+  {:indices opts})
 
 (defn has-child
   "Has Child query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html"
-  [& args]
-  {:has_child (ar/->opts args)})
+  [opts]
+  {:has_child opts})
 
 (defn custom-filters-score
   "Custom Filters Score query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-custom-filters-score-query.html"
-  [& args]
-  {:custom_filters_score (ar/->opts args)})
+  [opts]
+  {:custom_filters_score opts})
 
 (defn top-children
   "Top children query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-top-children-query.html"
-  [& args]
-  {:top_children (ar/->opts args)})
+  [opts]
+  {:top_children opts})
 
 (defn nested
   "Nested document query
 
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html"
-  [& args]
-  {:nested (ar/->opts args)})
+  [opts]
+  {:nested opts})
 
 (defn sort
   "Sort query results."

--- a/src/clojurewerkz/elastisch/rest/admin.clj
+++ b/src/clojurewerkz/elastisch/rest/admin.clj
@@ -14,8 +14,7 @@
 
 (ns clojurewerkz.elastisch.rest.admin
   (:require [clojurewerkz.elastisch.rest :as rest]
-            [clojurewerkz.elastisch.rest.utils :refer [join-names]]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojurewerkz.elastisch.rest.utils :refer [join-names]])
   (:import clojurewerkz.elastisch.rest.Connection))
 
 ;;
@@ -31,15 +30,15 @@
   (require '[clojurewerkz.elastisch.rest.admin :as admin])
 
   (admin/cluster-health conn)
-  (admin/cluster-health conn :index \"index1\")
-  (admin/cluster-health conn :index [\"index1\",\"index2\"])
-  (admin/cluster-health conn :index \"index1\" :pretty true :level \"indices\")
+  (admin/cluster-health conn {:index \"index1\"})
+  (admin/cluster-health conn {:index [\"index1\",\"index2\"]})
+  (admin/cluster-health conn {:index \"index1\" :pretty true :level \"indices\"})
   ```"
-  [^Connection conn & args]
-  (let [opts (ar/->opts args)]
-    (rest/get conn (rest/cluster-health-url conn
-                                            (join-names (:index opts)))
-              {:query-params (dissoc opts :index)})))
+  ([^Connection conn] (cluster-health conn nil))
+  ([^Connection conn opts]
+   (rest/get conn (rest/cluster-health-url conn
+                                           (join-names (:index opts)))
+             {:query-params (dissoc opts :index)})))
 
 (defn cluster-state
   "see <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-state.html>
@@ -51,8 +50,9 @@
 
   (admin/cluster-state conn)
   ```"
-  [^Connection conn & args]
-  (rest/get conn (rest/cluster-state-url conn) {:query-params (ar/->opts args)}))
+  ([^Connection conn] (cluster-state conn nil))
+  ([^Connection conn opts]
+   (rest/get conn (rest/cluster-state-url conn) {:query-params opts})))
 
 
 (defn nodes-stats
@@ -64,13 +64,13 @@
   (require '[clojurewerkz.elastisch.rest.admin :as admin])
 
   (admin/nodes-stats conn)
-  (admin/nodes-stats conn :nodes [\"10.0.0.1\", \"10.0.0.2\"] :attributes [\"os\" \"plugins\"])
+  (admin/nodes-stats conn {:nodes [\"10.0.0.1\", \"10.0.0.2\"] :attributes [\"os\" \"plugins\"]})
   ```"
-  [^Connection conn & args]
-  (let [opts (ar/->opts args)]
-    (rest/get conn (rest/cluster-nodes-stats-url conn
-                                                 (join-names (get opts :nodes "_all"))
-                                                 (join-names (get opts :attributes "_all"))))))
+  ([^Connection conn] (nodes-stats conn nil))
+  ([^Connection conn opts]
+   (rest/get conn (rest/cluster-nodes-stats-url conn
+                                                (join-names (get opts :nodes "_all"))
+                                                (join-names (get opts :attributes "_all"))))))
 
 (defn nodes-info
   "see <http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-info.html>
@@ -81,40 +81,41 @@
   (require '[clojurewerkz.elastisch.rest.admin :as admin])
 
   (admin/nodes-info conn)
-  (admin/nodes-info conn :nodes [\"10.0.0.1\", \"10.0.0.2\"] :attributes [\"os\" \"plugins\"])
+  (admin/nodes-info conn {:nodes [\"10.0.0.1\", \"10.0.0.2\"] :attributes [\"os\" \"plugins\"]})
   ```"
-  [^Connection conn & args]
-  (let [opts (ar/->opts args)]
-    (rest/get conn (rest/cluster-nodes-info-url conn
-                                                (join-names (get opts :nodes "_all"))
-                                                (join-names (get opts :attributes "_all"))))))
+  ([^Connection conn] (nodes-info conn nil))
+  ([^Connection conn opts]
+   (rest/get conn (rest/cluster-nodes-info-url conn
+                                               (join-names (get opts :nodes "_all"))
+                                               (join-names (get opts :attributes "_all"))))))
 
 
 (defn register-snapshot-repository
-  [^Connection conn ^String name & args]
-  (rest/put conn (rest/snapshot-repository-registration-url conn
-                                                            name)
-            {:body (ar/->opts args)}))
+  ([^Connection conn ^String name] (register-snapshot-repository conn name nil))
+  ([^Connection conn ^String name opts]
+   (rest/put conn (rest/snapshot-repository-registration-url conn
+                                                             name)
+             {:body opts})))
 
 
 (defn take-snapshot
-  [^Connection conn ^String repo ^String name & args]
-  (let [opts (ar/->opts args)]
-    (rest/put conn (rest/snapshot-url conn
-                                      repo name)
-              {:body opts :query-params (select-keys opts [:wait-for-completion?])})))
+  ([^Connection conn ^String repo ^String name] (take-snapshot conn repo name nil))
+  ([^Connection conn ^String repo ^String name opts]
+   (rest/put conn (rest/snapshot-url conn
+                                     repo name)
+             {:body opts :query-params (select-keys opts [:wait-for-completion?])})))
 
 (defn restore-snapshot
-  [^Connection conn ^String repo ^String name & args]
-  (let [opts (ar/->opts args)]
-    (rest/post conn (rest/restore-snapshot-url conn
-                                               repo name)
-             {:body opts
-              :query-params (select-keys opts [:wait-for-completion?])})))
+  ([^Connection conn ^String repo ^String name] (restore-snapshot conn repo name nil))
+  ([^Connection conn ^String repo ^String name opts]
+   (rest/post conn (rest/restore-snapshot-url conn
+                                              repo name)
+              {:body opts
+               :query-params (select-keys opts [:wait-for-completion?])})))
 
 (defn delete-snapshot
-  [^Connection conn ^String repo ^String name & args]
-  (let [opts (ar/->opts args)]
-    (rest/delete conn (rest/snapshot-url conn
-                                         repo name)
-                 {:query-params (select-keys opts [:wait-for-completion?])})))
+  ([^Connection conn ^String repo ^String name] (delete-snapshot conn repo name nil))
+  ([^Connection conn ^String repo ^String name opts]
+   (rest/delete conn (rest/snapshot-url conn
+                                        repo name)
+                {:query-params (select-keys opts [:wait-for-completion?])})))

--- a/src/clojurewerkz/elastisch/rest/bulk.clj
+++ b/src/clojurewerkz/elastisch/rest/bulk.clj
@@ -18,37 +18,39 @@
             [cheshire.core :as json]
             [clojure.string :as string]
             [clojure.set :refer :all]
-            [clojurewerkz.elastisch.common.bulk :as common-bulk]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojurewerkz.elastisch.common.bulk :as common-bulk])
   (:import clojurewerkz.elastisch.rest.Connection))
 
 (defn ^:private bulk-with-url
-  [conn url operations & args]
-  (let [opts      (ar/->opts args)
-        bulk-json (map json/encode operations)
-        bulk-json (-> bulk-json
-                      (interleave (repeat "\n"))
-                      (string/join))]
-    (rest/post-string conn url
-                      {:body bulk-json
-                       :query-params opts})))
+  ([conn url operations] (bulk-with-url conn url operations nil))
+  ([conn url operations opts]
+   (let [bulk-json (map json/encode operations)
+         bulk-json (-> bulk-json
+                       (interleave (repeat "\n"))
+                       (string/join))]
+     (rest/post-string conn url
+                       {:body bulk-json
+                        :query-params opts}))))
 (defn bulk
   "Performs a bulk operation"
-  [^Connection conn operations & params]
-  (when (not-empty operations)
-    (apply bulk-with-url conn (rest/bulk-url conn) operations params)))
+  ([^Connection conn operations] (bulk conn operations nil))
+  ([^Connection conn operations params]
+   (when (not-empty operations)
+     (bulk-with-url conn (rest/bulk-url conn) operations params))))
 
 (defn bulk-with-index
   "Performs a bulk operation defaulting to the index specified"
-  [^Connection conn index operations & params]
-  (apply bulk-with-url conn (rest/bulk-url conn
-                                           index) operations params))
+  ([^Connection conn index operations] (bulk-with-index conn index operations nil))
+  ([^Connection conn index operations params]
+   (bulk-with-url conn (rest/bulk-url conn
+                                      index) operations params)))
 
 (defn bulk-with-index-and-type
   "Performs a bulk operation defaulting to the index and type specified"
-  [^Connection conn index mapping-type operations & params]
-  (apply bulk-with-url conn (rest/bulk-url conn
-                                           index mapping-type) operations params))
+  ([^Connection conn index mapping-type operations] (bulk-with-index-and-type conn index mapping-type operations nil))
+  ([^Connection conn index mapping-type operations params]
+   (bulk-with-url conn (rest/bulk-url conn
+                                      index mapping-type) operations params)))
 
 (def index-operation common-bulk/index-operation)
 

--- a/src/clojurewerkz/elastisch/rest/multi.clj
+++ b/src/clojurewerkz/elastisch/rest/multi.clj
@@ -15,14 +15,12 @@
 (ns clojurewerkz.elastisch.rest.multi
   (:require [clojurewerkz.elastisch.rest :as rest]
             [cheshire.core :as json]
-            [clojure.string :as string]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [clojure.string :as string])
   (:import clojurewerkz.elastisch.rest.Connection))
 
 (defn ^:private msearch-with-url
-  [conn url queries args]
-  (let [opts (ar/->opts args)
-        body (string/join "\n" (doall (map json/encode queries)))]
+  [conn url queries opts]
+  (let [body (string/join "\n" (doall (map json/encode queries)))]
     (rest/get conn url
               ;; multi-search is sensitive to trailing new line. MK.
               {:body (str body "\n")
@@ -30,18 +28,21 @@
 
 (defn search
   "Performs multi search"
-  [conn queries & params]
-  (:responses (msearch-with-url conn (rest/multi-search-url conn) queries params)))
+  ([conn queries] (search conn queries nil))
+  ([conn queries params]
+   (:responses (msearch-with-url conn (rest/multi-search-url conn) queries params))))
 
 (defn search-with-index
   "Performs multi search defaulting to the index specified"
-  [^Connection conn index queries & params]
-  (:responses (msearch-with-url conn (rest/multi-search-url conn
-                                                            index) queries params)))
+  ([^Connection conn index queries] (search-with-index conn index queries nil))
+  ([^Connection conn index queries params]
+   (:responses (msearch-with-url conn (rest/multi-search-url conn
+                                                             index) queries params))))
 
 (defn search-with-index-and-type
   "Performs multi search defaulting to the index and type specified"
-  [^Connection conn index mapping-type queries & params]
-  (:responses (msearch-with-url conn (rest/multi-search-url conn
-                                                            index mapping-type)
-                     queries params)))
+  ([^Connection conn index mapping-type queries] (search-with-index-and-type conn index mapping-type queries nil))
+  ([^Connection conn index mapping-type queries params]
+   (:responses (msearch-with-url conn (rest/multi-search-url conn
+                                                             index mapping-type)
+                      queries params))))

--- a/src/clojurewerkz/elastisch/rest/percolation.clj
+++ b/src/clojurewerkz/elastisch/rest/percolation.clj
@@ -14,8 +14,7 @@
 
 (ns clojurewerkz.elastisch.rest.percolation
   (:require [clojurewerkz.elastisch.rest :as rest]
-            [cheshire.core :as json]
-            [clojurewerkz.elastisch.arguments :as ar])
+            [cheshire.core :as json])
   (:import clojurewerkz.elastisch.rest.Connection))
 
 ;;
@@ -24,10 +23,11 @@
 
 (defn register-query
   "Registers a percolator for the given index"
-  [^Connection conn index percolator & args]
-  (rest/put conn (rest/percolator-url conn
-                                      index percolator)
-            {:body (ar/->opts args)}))
+  ([^Connection conn index percolator] (register-query conn index percolator nil))
+  ([^Connection conn index percolator opts]
+   (rest/put conn (rest/percolator-url conn
+                                       index percolator)
+             {:body opts})))
 
 (defn unregister-query
   "Unregisters a percolator query for the given index"
@@ -38,11 +38,12 @@
 (defn percolate
   "Percolates a document and see which queries match on it. The document is not indexed, just
   matched against the queries you register with [[register-query]]."
-  [^Connection conn index percolator & args]
-  ;; rest/get won't serialize the body for us. MK.
-  (rest/get conn (rest/index-percolation-url conn
-                                             index percolator)
-            {:body (json/encode (ar/->opts args))}))
+  ([^Connection conn index percolator] (percolate conn index percolator nil))
+  ([^Connection conn index percolator opts]
+   ;; rest/get won't serialize the body for us. MK.
+   (rest/get conn (rest/index-percolation-url conn
+                                              index percolator)
+             {:body (json/encode opts)})))
 
 (defn percolate-existing
   "Percolates an existing document and sees which queries match on it."

--- a/test/clojurewerkz/elastisch/fixtures.clj
+++ b/test/clojurewerkz/elastisch/fixtures.clj
@@ -289,7 +289,7 @@
   [f]
   (let [index-name   "people"
         mapping-type "person"]
-    (idx/create conn index-name :mappings people-mapping)
+    (idx/create conn index-name {:mappings people-mapping})
 
     (is (created? (doc/put conn index-name mapping-type "1" person-jack)))
     (is (created? (doc/put conn index-name mapping-type "2" person-mary)))
@@ -303,7 +303,7 @@
   [f]
   (let [index-name   "articles"
         mapping-type "article"]
-    (idx/create conn index-name :mappings articles-mapping)
+    (idx/create conn index-name {:mappings articles-mapping})
 
     (is (created? (doc/put conn index-name mapping-type "1" article-on-elasticsearch)))
     (is (created? (doc/put conn index-name mapping-type "2" article-on-lucene)))
@@ -317,7 +317,7 @@
   [f]
   (let [index-name   "tweets"
         mapping-type "tweet"]
-    (idx/create conn index-name :mappings tweets-mapping)
+    (idx/create conn index-name {:mappings tweets-mapping})
 
     (is (created? (doc/put conn index-name mapping-type "1" tweet1)))
     (is (created? (doc/put conn index-name mapping-type "2" tweet2)))
@@ -332,7 +332,7 @@
   [f]
   (let [index-name "people_suggestions"
         mapping-type "person_suggestions"]
-    (idx/create conn index-name :mappings people-suggestion-mapping)
+    (idx/create conn index-name {:mappings people-suggestion-mapping})
     ;; seeds suggestion data
     (is (created? (doc/put conn index-name mapping-type "1" suggest-jack)))
     (is (created? (doc/put conn index-name mapping-type "2" suggest-mary)))
@@ -346,7 +346,7 @@
   [f]
   (let [index-name "people_with_category"
         mapping-type "person_suggestions"]
-    (idx/create conn index-name :mappings people-suggestion-gender-context-mapping)
+    (idx/create conn index-name {:mappings people-suggestion-gender-context-mapping})
     ;; seeds suggestion data
     (is (created? (doc/put conn index-name mapping-type "1"
                            (assoc-in suggest-jack [:suggest :context] {:gender "male"}))))
@@ -366,7 +366,7 @@
         mapping-type "person_suggestions"
         local {:location {:lat 90.0 :lon 90.0}}
         faraway {:location {:lat 0.0 :lon -90.0}}]
-    (idx/create conn index-name :mappings people-suggestion-location-context-mapping)
+    (idx/create conn index-name {:mappings people-suggestion-location-context-mapping})
     ;; seeds suggestion data
     (is (created? (doc/put conn index-name mapping-type "1"
                            (assoc-in suggest-jack [:suggest :context] local))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/avg_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/avg_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:avg_age (a/avg "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:avg_age (a/avg "age")}})
           agg          (aggregation-from response :avg_age)]
       (is (= {:value 29.0} agg)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/cardinality_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/cardinality_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:username_count {:cardinality {:field "username"}}})
+                                   {:query (q/match-all)
+                                    :aggregations {:username_count {:cardinality {:field "username"}}}})
           agg          (aggregation-from response :username_count)]
       (is (>= (:value agg) 4)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/date_histogram_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/date_histogram_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/date-histogram "signed_up_at" "1d")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/date-histogram "signed_up_at" "1d")}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg))))
 
@@ -32,10 +32,10 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges
-                                                  (merge
-                                                   {:aggs {:avg_age (a/avg "age")}}
-                                                   (a/date-histogram "signed_up_at" "1d"))})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges
+                                                   (merge
+                                                    {:aggs {:avg_age (a/avg "age")}}
+                                                    (a/date-histogram "signed_up_at" "1d"))}})
           agg          (aggregation-from response :age_ranges)]
       (is (= (count (:buckets agg)) (count (filter #(contains? % :avg_age) (:buckets agg))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/date_range_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/date_range_aggregation_test.clj
@@ -23,11 +23,11 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/date-range "signed_up_at"
-                                                                            "date_hour_minute_second"
-                                                                            [{:from "2012-02-01T00:00:00" :to "2012-02-29T23:59:59"}
-                                                                             {:from "2012-03-01T00:00:00"}])})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/date-range "signed_up_at"
+                                                                             "date_hour_minute_second"
+                                                                             [{:from "2012-02-01T00:00:00" :to "2012-02-29T23:59:59"}
+                                                                              {:from "2012-03-01T00:00:00"}])}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg))))
 
@@ -35,12 +35,12 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (merge
-                                                               {:aggs {:avg_age (a/avg "age")}}
-                                                               (a/date-range "signed_up_at"
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (merge
+                                                                {:aggs {:avg_age (a/avg "age")}}
+                                                                (a/date-range "signed_up_at"
                                                                              "date_hour_minute_second"
                                                                              [{:from "2012-02-01T00:00:00" :to "2012-02-29T23:59:59"}
-                                                                              {:from "2012-03-01T00:00:00"}]))})
+                                                                              {:from "2012-03-01T00:00:00"}]))}})
           agg          (aggregation-from response :age_ranges)]
       (is (= (count (:buckets agg)) (count (filter #(contains? % :avg_age) (:buckets agg))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/extended_stats_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/extended_stats_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_stats (a/extended-stats "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_stats (a/extended-stats "age")}})
           agg          (aggregation-from response :age_stats)]
       (is (= #{:count :min :max :avg :sum :std_deviation :sum_of_squares :variance}
              (set (keys agg)))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/histogram_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/histogram_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_histograms (a/histogram "age" 5)})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_histograms (a/histogram "age" 5)}})
           agg          (aggregation-from response :age_histograms)]
       (is (:buckets agg))))
 
@@ -32,9 +32,9 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_histograms (merge
-                                                                   {:aggs {:avg_age (a/avg "age")}}
-                                                                   (a/histogram "age" 5))})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_histograms (merge
+                                                                    {:aggs {:avg_age (a/avg "age")}}
+                                                                    (a/histogram "age" 5))}})
           agg          (aggregation-from response :age_histograms)]
       (is (= (count (:buckets agg)) (count (filter #(contains? % :avg_age) (:buckets agg))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/max_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/max_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:max_age (a/max "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:max_age (a/max "age")}})
           agg          (aggregation-from response :max_age)]
       (is (= {:value 37.0} agg)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/min_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/min_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:min_age (a/min "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:min_age (a/min "age")}})
           agg          (aggregation-from response :min_age)]
       (is (= {:value 22.0} agg)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/missing_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/missing_aggregation_test.clj
@@ -23,7 +23,7 @@
   (let [index-name   "people"
         mapping-type "person"
         response     (doc/search conn index-name mapping-type
-                                 :query (q/match-all)
-                                 :aggregations {:no_country (a/missing :country)})
+                                 {:query (q/match-all)
+                                  :aggregations {:no_country (a/missing :country)}})
         agg          (aggregation-from response :no_country)]
     (is (>= (:doc_count agg) 3)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/percentiles_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/percentiles_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:percentiles_age (a/percentiles "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:percentiles_age (a/percentiles "age")}})
           agg          (aggregation-from response :percentiles_age)]
       (is (= #{:1.0 :5.0 :25.0 :50.0 :75.0 :95.0 :99.0}
              (set (keys (get agg :values))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/range_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/range_aggregation_test.clj
@@ -23,11 +23,11 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/range "age" [{:from 15 :to 20}
-                                                                              {:from 21 :to 25}
-                                                                              {:from 26 :to 30}
-                                                                              {:from 31}])})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/range "age" [{:from 15 :to 20}
+                                                                               {:from 21 :to 25}
+                                                                               {:from 26 :to 30}
+                                                                               {:from 31}])}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg))))
 
@@ -35,12 +35,12 @@
       (let [index-name   "people"
             mapping-type "person"
             response     (doc/search conn index-name mapping-type
-                                     :query (q/match-all)
-                                     :aggregations {:age_ranges (merge
-                                                                 {:aggs {:avg_age (a/avg "age")}}
-                                                                 (a/range "age" [{:from 15 :to 20}
-                                                                                 {:from 21 :to 25}
-                                                                                 {:from 26 :to 30}
-                                                                                 {:from 31}]))})
+                                     {:query (q/match-all)
+                                      :aggregations {:age_ranges (merge
+                                                                  {:aggs {:avg_age (a/avg "age")}}
+                                                                  (a/range "age" [{:from 15 :to 20}
+                                                                                  {:from 21 :to 25}
+                                                                                  {:from 26 :to 30}
+                                                                                  {:from 31}]))}})
             agg          (aggregation-from response :age_ranges)]
       (is (= (count (:buckets agg)) (count (filter #(contains? % :avg_age) (:buckets agg))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/stats_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/stats_aggregation_test.clj
@@ -24,7 +24,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_stats (a/stats "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_stats (a/stats "age")}})
           agg          (aggregation-from response :age_stats)]
       (is (= #{:count :min :max :avg :sum} (set (keys agg)))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/sum_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/sum_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:sum_age (a/sum "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:sum_age (a/sum "age")}})
           agg          (aggregation-from response :sum_age)]
       (is (>= (:value agg) 116)))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/terms_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/terms_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:title_terms (a/terms "title")})
+                                   {:query (q/match-all)
+                                    :aggregations {:title_terms (a/terms "title")}})
           agg          (aggregation-from response :title_terms)]
       (is (= 6 (count (:buckets agg))))))
 
@@ -32,9 +32,9 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:title_terms (merge
-                                                                {:aggs {:avg_age (a/avg "age")}}
-                                                                (a/terms "title"))})
+                                   {:query (q/match-all)
+                                    :aggregations {:title_terms (merge
+                                                                 {:aggs {:avg_age (a/avg "age")}}
+                                                                 (a/terms "title"))}})
           agg          (aggregation-from response :title_terms)]
       (is (= 6 (count (filter #(contains? % :avg_age) (:buckets agg))))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/top_hits_aggregations_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/top_hits_aggregations_test.clj
@@ -14,11 +14,11 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations
-                                   {:top-hits
-                                    {:top_hits {:sort [{:title {:order "asc"}}]
-                                                :size 4}}})
+                                   {:query (q/match-all)
+                                    :aggregations
+                                    {:top-hits
+                                     {:top_hits {:sort [{:title {:order "asc"}}]
+                                                 :size 4}}}})
           agg          (aggregation-from response :top-hits)]
       (is (= 4 (get-in agg [:hits :total])))
       (is (= 4 (count (get-in agg [:hits :hits])))))))

--- a/test/clojurewerkz/elastisch/native_api/aggregations/value_count_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/aggregations/value_count_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:agg1 (a/value-count "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:agg1 (a/value-count "age")}})
           agg          (aggregation-from response :agg1)]
       (is (>= (:value agg) 4)))))

--- a/test/clojurewerkz/elastisch/native_api/count_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/count_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:native true} test-count-with-the-default-query
     (let [index-name "people"
           index-type "person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/create conn index-name index-type fx/person-jack)
       (doc/create conn index-name index-type fx/person-joe)
       (idx/refresh conn index-name)
@@ -32,7 +32,7 @@
   (deftest ^{:native true} test-count-with-a-term-query
     (let [index-name "people"
           index-type "person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/create conn index-name index-type fx/person-jack)
       (doc/create conn index-name index-type fx/person-joe)
       (idx/refresh conn index-name)
@@ -45,7 +45,7 @@
     (let [index-name "people"
           index-type "person"
           alt-index-type "altperson"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/create conn index-name index-type fx/person-jack)
       (doc/create conn index-name index-type fx/person-joe)
       (doc/create conn index-name "altperson" fx/person-jack)

--- a/test/clojurewerkz/elastisch/native_api/filtering_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/filtering_test.clj
@@ -25,8 +25,8 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:term {:username "esmary"}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:term {:username "esmary"}}}))]
       (is (= 1 (count hits)))
       (is (= "Lindey" (-> hits first :_source :last-name)))))
 
@@ -34,7 +34,7 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:range {:age {:from 26 :to 30}}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:range {:age {:from 26 :to 30}}}}))]
       (is (= 2 (count hits)))
       (is (#{28 29} (-> hits first :_source :age))))))

--- a/test/clojurewerkz/elastisch/native_api/highlighting_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/highlighting_test.clj
@@ -24,14 +24,14 @@
   (deftest ^{:native true} test-highlighting-with-all-defaults
     (let [index "articles"
           type  "article"]
-      (idx/create conn index :mappings fx/articles-mapping)
+      (idx/create conn index {:mappings fx/articles-mapping})
       (doc/put conn index type "1" fx/article-on-elasticsearch)
       (doc/put conn index type "2" fx/article-on-lucene)
       (doc/put conn index type "3" fx/article-on-nueva-york)
       (doc/put conn index type "4" fx/article-on-austin)
       (idx/refresh conn index)
       (let [resp  (doc/search conn index type
-                              {:query (q/query-string :query "software" :default_field "summary")
+                              {:query (q/query-string {:query "software" :default_field "summary"})
                                :highlight {:fields {:summary {}}}})
             hits  (hits-from resp)]
         (is (re-find #"<em>software</em>" (-> hits first :highlight :summary first)))))))

--- a/test/clojurewerkz/elastisch/native_api/indexing_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indexing_test.clj
@@ -81,7 +81,7 @@
   (let [id       "1"
         _        (doc/put conn index-name index-type id fx/person-jack)
         _        (doc/put conn index-name index-type id fx/person-mary)
-        response (doc/put conn index-name index-type id fx/person-joe :version 2)]
+        response (doc/put conn index-name index-type id fx/person-joe {:version 2})]
     (is (:_index response))
     (is (:_type response))))
 
@@ -105,28 +105,28 @@
 (deftest ^{:indexing true :native true} test-create-when-already-created
   (let [id       "1"
         _        (doc/put conn index-name index-type id fx/person-jack)
-        response (doc/put conn index-name index-type id fx/person-joe :op_type "create")]
+        response (doc/put conn index-name index-type id fx/person-joe {:op_type "create"})]
     (is (:_index response))
     (is (:_type response))))
 
 (deftest ^{:indexing true :native true} test-sync-put-with-a-timestamp
   (let [id       "1"
-        _        (idx/create conn index-name :mappings fx/people-mapping)
-        response (doc/put conn index-name index-type id fx/person-jack :timestamp "2009-11-15T14:12:12")]
+        _        (idx/create conn index-name {:mappings fx/people-mapping})
+        response (doc/put conn index-name index-type id fx/person-jack {:timestamp "2009-11-15T14:12:12"})]
     (is (:_index response))
     (is (:_type response))))
 
 (deftest ^{:indexing true :native true} test-sync-put-with-a-10-seconds-ttl
   (let [id       "1"
-        _        (idx/create conn index-name :mappings fx/people-mapping)
-        response (doc/put conn index-name index-type id fx/person-jack :ttl 10000)]
+        _        (idx/create conn index-name {:mappings fx/people-mapping})
+        response (doc/put conn index-name index-type id fx/person-jack {:ttl 10000})]
     (is (:_index response))
     (is (:_type response))))
 
 (deftest ^{:indexing true :native true} test-sync-put-with-refresh-set-to-true
   (let [id       "1"
-        _        (idx/create conn index-name :mappings fx/people-mapping)
-        response (doc/put conn index-name index-type id fx/person-jack :refresh true)]
+        _        (idx/create conn index-name {:mappings fx/people-mapping})
+        response (doc/put conn index-name index-type id fx/person-jack {:refresh true})]
     (is (:_index response))
     (is (:_type response))))
 

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -32,29 +32,29 @@
       (is (not (idx/type-exists? conn "elastisch-index-without-mappings" "person")))))
 
   (deftest ^{:indexing true :native true} test-create-an-index-with-settings
-    (let [response (idx/create conn "elastisch-index-without-mappings" :settings {"index" {"number_of_shards" 1}})]
+    (let [response (idx/create conn "elastisch-index-without-mappings" {:settings {"index" {"number_of_shards" 1}}})]
       (is (acknowledged? response))))
 
   (deftest ^{:indexing true :native true} test-create-index-accepts-keywordized-keys-in-settings
-    (let [response (idx/create conn "elastisch-index-with-settings" :settings {:index {:refresh_interval "42s"}})]
+    (let [response (idx/create conn "elastisch-index-with-settings" {:settings {:index {:refresh_interval "42s"}}})]
       (is (acknowledged? response))))
 
   (deftest ^{:indexing true :native true} test-successful-creation-of-index-with-mappings-and-without-settings
     (let [index    "people"
-          response (idx/create conn index :mappings fx/people-mapping)]
+          response (idx/create conn index {:mappings fx/people-mapping})]
       (is (idx/exists? conn index))
       (is (idx/type-exists? conn index "person"))))
 
   (deftest ^{:indexing true :native true} test-successful-deletion-of-index
     (let [index    "people"
-          _        (idx/create conn index :mappings fx/people-mapping)
+          _        (idx/create conn index {:mappings fx/people-mapping})
           response (idx/delete conn index)]
       (is (not (idx/exists? conn index)))))
 
   (deftest ^{:native true :indexing true} test-getting-index-settings
       (let [index     "people"
             settings  {"index" {"refresh_interval" "1s"}}
-            response  (idx/create conn index :settings settings :mappings fx/people-mapping)
+            response  (idx/create conn index {:settings settings :mappings fx/people-mapping})
             settings' (idx/get-settings conn "people")]
         (acknowledged? response)
         (is (= "1s" (get-in settings' [:people :settings :index :refresh_interval])))))
@@ -62,41 +62,41 @@
   (deftest ^{:indexing true :native true} testing-updating-specific-index-settings
     (let [index     "people"
           settings  {:index {:refresh_interval "1s"}}
-          _         (idx/create conn index :mappings fx/people-mapping)]
+          _         (idx/create conn index {:mappings fx/people-mapping})]
       (is (idx/update-settings conn index settings))))
 
   (deftest ^{:indexing true :native true} test-force-merge-index
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/force-merge conn index :only_expunge_deletes 1)]
+          _         (idx/create conn index {:mappings fx/people-mapping})
+          response  (idx/force-merge conn index {:only_expunge_deletes 1})]
       (is (broadcast-operation-response? response))))
 
   (deftest ^{:indexing true :native true} test-flush-index
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           response  (idx/flush conn index)]
       (is (broadcast-operation-response? response))))
 
   (deftest ^{:indexing true :native true} test-refresh-index
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           response  (idx/refresh conn index)]
       (is (broadcast-operation-response? response))))
 
   (deftest ^{:indexing true :native true} test-clear-index-cache-with-refresh
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/clear-cache conn index :filter true :field_data true)]
+          _         (idx/create conn index {:mappings fx/people-mapping})
+          response  (idx/clear-cache conn index {:filter true :field_data true})]
       (is (broadcast-operation-response? response))))
 
   (deftest ^{:indexing true :native true} test-index-stats-for-all-indexes
     (idx/create conn "group1")
     (idx/create conn "group2")
-    (is (idx/stats conn :docs true :store true :indexing true)))
+    (is (idx/stats conn {:docs true :store true :indexing true})))
 
   (deftest ^{:indexing true :native true} test-indices-with-aliases
-    (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
-    (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index1" {:settings {"index" {"refresh_interval" "42s"}}})
+    (idx/create conn "aliased-index2" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged?
           (idx/update-aliases conn [{:add {:alias "alias1" :index "aliased-index1"}}
                                     {:add {:alias "alias2" :index "aliased-index2"}}])))
@@ -108,38 +108,38 @@
     (is (not (doc/get conn "alias2" "type" "id1"))))
 
   (deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices ["aliased-index"]}}
                                                  {:add {:alias "alias2" :indices ["aliased-index"]}}]))))
 
   (deftest ^{:indexing true :native true} test-create-an-index-with-two-aliases-using-plural-aliases-syntax 
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged? (idx/update-aliases conn [{:add {:aliases ["alias1" "alias2"] :index "aliased-index"}}])))
     (is (doc/put conn "aliased-index" "type" "id1" {}))
     (is (doc/get conn "alias1" "type" "id1"))
     (is (doc/get conn "alias2" "type" "id1")))
 
   (deftest ^{:indexing true :native true} test-create-an-index-with-an-alias-and-delete-it
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged? (idx/update-aliases conn [{:add {:alias "alias1" :indices "aliased-index"}}])))
     (is (acknowledged? (idx/update-aliases conn [{:remove {:aliases "alias1" :index "aliased-index"}}]))))
 
   (deftest ^{:indexing true :native true} test-remove-alias-allows-singular-alias
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged? (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}])))
     (is (acknowledged? (idx/update-aliases conn [{:remove {:index "aliased-index" :alias "alias1"}}]))))
 
   (deftest ^{:indexing true :native true} test-remove-alias-allows-multiple-indices
-    (idx/create conn "aliased-index1" :settings {"index" {"refresh_interval" "42s"}})
-    (idx/create conn "aliased-index2" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index1" {:settings {"index" {"refresh_interval" "42s"}}})
+    (idx/create conn "aliased-index2" {:settings {"index" {"refresh_interval" "42s"}}})
     (is (acknowledged? (idx/update-aliases conn [{:add {:indices ["aliased-index1" "aliased-index2"] :alias "alias"}}])))
     (is (acknowledged? (idx/update-aliases conn [{:remove {:alias "alias" :indices ["aliased-index1" "aliased-index2"]}}]))))
 
   (deftest ^{:indexing true :native true} test-create-an-index-template-and-fetch-it
-    (let [response (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})]
+    (let [response (idx/create-template conn "accounts" {:template "account*" :settings {:index {:refresh_interval "60s"}}})]
       (is (acknowledged? response))))
 
   (deftest ^{:indexing true :native true} test-create-an-index-template-and-delete-it
-     (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})
+     (idx/create-template conn "accounts" {:template "account*" :settings {:index {:refresh_interval "60s"}}})
      (is (acknowledged? (idx/delete-template conn "accounts")))))
 

--- a/test/clojurewerkz/elastisch/native_api/mappings_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/mappings_test.clj
@@ -21,8 +21,8 @@
     (let [index    "people1"
           mapping  fx/people-mapping
           orig-mapping {:person {:properties {:first-name {:type "string" :store "yes"}}}}
-          _        (idx/create conn index :mappings orig-mapping)
-          response (idx/update-mapping conn index "person" :mapping mapping)]
+          _        (idx/create conn index {:mappings orig-mapping})
+          response (idx/update-mapping conn index "person" {:mapping mapping})]
       (is (resp/created-or-acknowledged? response))
       (is (get-in (idx/get-mapping conn index) [:people1 :mappings :person :properties :username :store]))))
 
@@ -30,6 +30,6 @@
   (deftest ^{:native true} test-updating-blank-index-mapping
     (let [index    "people3"
           mapping  fx/people-mapping
-          _        (idx/create conn index :mappings {})
-          response (idx/update-mapping conn index "person" :mapping mapping)]
+          _        (idx/create conn index {:mappings {}})
+          response (idx/update-mapping conn index "person" {:mapping mapping})]
       (is (resp/created-or-acknowledged? response)))))

--- a/test/clojurewerkz/elastisch/native_api/multi_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/multi_test.clj
@@ -21,8 +21,8 @@
 
 (let [conn (th/connect-native-client)]
   (deftest ^{:rest true} test-multi-search
-    (let [res1 (doc/search conn "people" "person" :query (q/match-all) :size 1)
-          res2 (doc/search conn "articles" "article" :query (q/match-all) :size 1)
+    (let [res1 (doc/search conn "people" "person" {:query (q/match-all) :size 1})
+          res2 (doc/search conn "articles" "article" {:query (q/match-all) :size 1})
           multires (multi/search conn [{:index "people" :type "person"} {:query (q/match-all) :size 1}
                                        {:index "articles" :type "article"} {:query (q/match-all) :size 1}])]
       (is (= (-> res1 :hits :hits first :_source)
@@ -31,8 +31,8 @@
              (-> multires second :hits :hits first :_source)))))
 
   (deftest ^{:rest true} test-multi-with-index-and-type
-    (let [res1 (doc/search conn "people" "person" :query (q/term :planet "earth"))
-          res2 (doc/search conn "people" "person" :query (q/term :first-name "mary"))
+    (let [res1 (doc/search conn "people" "person" {:query (q/term :planet "earth")})
+          res2 (doc/search conn "people" "person" {:query (q/term :first-name "mary")})
           multires (multi/search-with-index-and-type conn
                                                      "people" "person"
                                                      [{} {:query (q/term :planet "earth")}

--- a/test/clojurewerkz/elastisch/native_api/percolation_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/percolation_test.clj
@@ -30,8 +30,8 @@
         _            (idx/create conn index-name
                                  {:mappings fx/articles-mapping
                                   :settings {"index.number_of_shards" 1}})
-        result1      (pcl/register-query conn index-name query-name :query {:term {:title "search"}})
-        result2      (pcl/percolate conn index-name "article" :doc {:title "You know, for search"} :refresh true)
+        result1      (pcl/register-query conn index-name query-name {:query {:term {:title "search"}}})
+        result2      (pcl/percolate conn index-name "article" {:doc {:title "You know, for search"} :refresh true})
         result3      (pcl/unregister-query conn index-name query-name)]
     (is (= [query-name] (matches-from result2)))
     (is (= index-name (:_index result3)))

--- a/test/clojurewerkz/elastisch/native_api/queries/bool_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/bool_query_test.clj
@@ -22,9 +22,9 @@
   (deftest ^{:query true :native true} test-basic-bool-query
     (let [index-name   "people"
           mapping-type "person"
-          response     (doc/search conn index-name mapping-type :query (q/bool :must   {:term {:planet "earth"}}
-                                                                               :should {:range {:age {:from 20 :to 30}}}
-                                                                               :minimum_number_should_match 1))]
+          response     (doc/search conn index-name mapping-type {:query (q/bool {:must   {:term {:planet "earth"}}
+                                                                                 :should {:range {:age {:from 20 :to 30}}}
+                                                                                 :minimum_number_should_match 1})})]
       (is (any-hits? response))
       (is (= (sort (ids-from response)) (sort ["1" "2" "4"])))
       (is (= 3 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/filtered_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/filtered_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:query true :native true} test-basic-filtered-query
     (let [index-name   "people"
           mapping-type "person"
-          response     (doc/search conn index-name mapping-type {:query (q/filtered :query  (q/term :planet "earth")
-                                                                                    :filter {:range {:age {:from 20 :to 30}}})})]
+          response     (doc/search conn index-name mapping-type {:query (q/filtered {:query  (q/term :planet "earth")
+                                                                                     :filter {:range {:age {:from 20 :to 30}}}})})]
       (is (any-hits? response))
       (is (= 3 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/fuzzy_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/fuzzy_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:query true :native true} test-basic-fuzzy-query-with-string-fields
   (let [index-name   "articles"
         mapping-type "article"
-        response     (doc/search conn index-name mapping-type :query (q/fuzzy :title "Nueva"))
+        response     (doc/search conn index-name mapping-type {:query (q/fuzzy {:title "Nueva"})})
         hits         (hits-from response)]
     (is (any-hits? response))
     (is (= 1 (total-hits response)))
@@ -31,7 +31,7 @@
 (deftest ^{:query true :native true} test-basic-fuzzy-query-with-numeric-fields
   (let [index-name   "articles"
         mapping-type "article"
-        response (doc/search conn index-name mapping-type :query (q/fuzzy :number-of-edits {:value 13000 :fuzziness 3}))
+        response (doc/search conn index-name mapping-type {:query (q/fuzzy {:number-of-edits {:value 13000 :fuzziness 3}})})
         hits     (hits-from response)]
     (is (any-hits? response))
     (is (= 1 (total-hits response)))

--- a/test/clojurewerkz/elastisch/native_api/queries/ids_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/ids_query_test.clj
@@ -20,7 +20,7 @@
 
 (let [conn (th/connect-native-client)]
   (deftest ^{:query true :native true} test-basic-ids-query
-  (let [response (doc/search conn "tweets" "tweet" :query (q/ids "tweet" ["1" "2" "8ska88"]))]
+  (let [response (doc/search conn "tweets" "tweet" {:query (q/ids "tweet" ["1" "2" "8ska88"])})]
     (is (any-hits? response))
     (is (= 2 (total-hits response)))
     (is (= #{"1" "2"} (set (map :_id (hits-from response))))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/match_all_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/match_all_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:query true :native true} test-basic-match-all-query
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/match-all))
+          response     (doc/search conn index-name mapping-type {:query (q/match-all)})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 4 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/mlt_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/mlt_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:query true :native true} test-more-like-this-query
   (let [index-name   "articles"
         mapping-type "article"
-        response (doc/search conn index-name mapping-type :query (q/mlt :like_text "technology, opensource, search, full-text search, distributed, software, lucene"
-                                                                   :fields ["tags"] :min_term_freq 1 :min_doc_freq 1))]
+        response (doc/search conn index-name mapping-type {:query (q/mlt {:like_text "technology, opensource, search, full-text search, distributed, software, lucene"
+                                                                   :fields ["tags"] :min_term_freq 1 :min_doc_freq 1})})]
     (is (= 2 (total-hits response)))
     (is (= #{"1" "2"} (ids-from response))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/prefix_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/prefix_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:query true :native true} test-basic-prefix-query
   (let [index-name   "people"
         mapping-type "person"
-        response     (doc/search conn index-name mapping-type :query (q/prefix :username "esj"))
+        response     (doc/search conn index-name mapping-type {:query (q/prefix {:username "esj"})})
         hits         (hits-from response)]
     (is (any-hits? response))
     (is (= 2 (total-hits response)))
@@ -31,7 +31,7 @@
 (deftest ^{:query true :native true} test-full-word-prefix-query-over-a-text-field-analyzed-with-the-standard-analyzer
   (let [index-name   "tweets"
         mapping-type "tweet"
-        response (doc/search conn index-name mapping-type :query (q/prefix :text "why"))
+        response (doc/search conn index-name mapping-type {:query (q/prefix {:text "why"})})
         hits     (hits-from response)]
     (is (= 1 (total-hits response)))
     (is (= "4" (-> hits first :_id)))))
@@ -39,7 +39,7 @@
 (deftest ^{:query true :native true} test-partial-prefix-query-over-a-text-field
   (let [index-name   "tweets"
         mapping-type "tweet"
-        response (doc/search conn index-name mapping-type :query (q/prefix :text "congr"))
+        response (doc/search conn index-name mapping-type {:query (q/prefix {:text "congr"})})
         hits     (hits-from response)]
     (is (= 1 (total-hits response)))
     (is (= "3" (-> hits first :_id))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/query_string_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/query_string_query_test.clj
@@ -23,26 +23,26 @@
   (deftest ^{:query true :native true} test-query-string-query
   (let [index-name   "articles"
         mapping-type "article"
-        response     (doc/search conn index-name mapping-type :query (q/query-string :query "Austin" :default_field "title"))]
+        response     (doc/search conn index-name mapping-type {:query (q/query-string {:query "Austin" :default_field "title"})})]
     (is (= 1 (total-hits response)))
     (is (= #{"4"} (ids-from response)))))
 
 ;; ES native client seems to ignore special index and type names such as _all. MK.
 (deftest ^{:query true :native true} test-query-string-query-across-all-mapping-types
   (let [index-name   "articles"
-        response     (doc/search-all-types conn index-name :query (q/query-string :query "Austin" :default_field "title"))]
+        response     (doc/search-all-types conn index-name {:query (q/query-string {:query "Austin" :default_field "title"})})]
     (is (= 1 (total-hits response)))
     (is (= #{"4"} (ids-from response)))))
 
 (deftest ^{:query true :native true} test-query-string-query-across-all-indexes-and-mapping-types
-  (let [response     (doc/search-all-indexes-and-types conn :query (q/query-string :query "Austin" :default_field "title"))]
+  (let [response     (doc/search-all-indexes-and-types conn {:query (q/query-string {:query "Austin" :default_field "title"})})]
     (is (= 1 (total-hits response)))
     (is (= #{"4"} (ids-from response)))))
 
 (deftest ^{:query true :native true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case1
   (let [index-name   "tweets"
         mapping-type "tweet"
-        response (doc/search conn index-name mapping-type :query (q/query-string :query "cloud+"))
+        response (doc/search conn index-name mapping-type {:query (q/query-string {:query "cloud+"})})
         hits     (hits-from response)]
     (is (= 1 (total-hits response)))
     (is (= "5" (-> hits first :_id)))))
@@ -50,6 +50,6 @@
 (deftest ^{:query true :native true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case2
   (let [index-name   "tweets"
         mapping-type "tweet"
-        response (doc/search conn index-name mapping-type :query (q/query-string :query "cloud AND (NOT adoption)"))
+        response (doc/search conn index-name mapping-type {:query (q/query-string {:query "cloud AND (NOT adoption)"})})
         hits     (hits-from response)]
     (is (= 0 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/range_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/range_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:query true :native true} test-range-query-over-numerical-field
   (let [index-name   "people"
         mapping-type "person"
-        response     (doc/search conn index-name mapping-type :query (q/range :age :from 27 :to 29))
+        response     (doc/search conn index-name mapping-type {:query (q/range :age {:from 27 :to 29})})
         hits         (hits-from response)]
     (is (any-hits? response))
     (is (= 2 (total-hits response)))
@@ -32,19 +32,19 @@
 (let [index-name   "tweets"
       mapping-type "tweet"]
   (deftest ^{:query true :native true} test-range-query-over-string-field
-    (let [response (doc/search conn index-name mapping-type :query (q/range :username :from "c" :to "j"))
+    (let [response (doc/search conn index-name mapping-type {:query (q/range :username {:from "c" :to "j"})})
           ids      (ids-from response)]
       (is (= 2 (total-hits response)))
       (is (= #{"1" "2"} ids))))
 
   (deftest ^{:query true :native true} test-range-query-over-date-time-field-with-from
-    (let [response (doc/search conn index-name mapping-type :query (q/range :timestamp :from "20120801T160000+0100"))
+    (let [response (doc/search conn index-name mapping-type {:query (q/range :timestamp {:from "20120801T160000+0100"})})
           ids      (ids-from response)]
       (is (= 2 (total-hits response)))
       (is (= #{"1" "2"} ids))))
 
   (deftest ^{:query true :native true} test-range-query-over-date-time-field-with-from-and-to
-     (let [response (doc/search conn index-name mapping-type :query (q/range :timestamp :from "20120801T160000+0100" :to "20120801T180000+0100"))
+     (let [response (doc/search conn index-name mapping-type {:query (q/range :timestamp {:from "20120801T160000+0100" :to "20120801T180000+0100"})})
            ids      (ids-from response)]
        (is (= 1 (total-hits response)))
        (is (= #{"2"} ids))))))

--- a/test/clojurewerkz/elastisch/native_api/queries/term_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/term_query_test.clj
@@ -21,30 +21,30 @@
 
 (let [conn (th/connect-native-client)]
   (deftest ^{:query true :native true} test-basic-term-query-with-person-mapping
-    (let [result (doc/search conn "people" "person" :query (q/term :biography "avoid"))]
+    (let [result (doc/search conn "people" "person" {:query (q/term :biography "avoid")})]
       (is (any-hits? result))
       (is (= fx/person-jack (-> result hits-from first :_source)))))
 
 
   (deftest ^{:query true :native true} test-term-query-with-person-mapping-and-a-limit
-    (let [result (doc/search conn "people" "person" :query (q/term :planet "earth") :size 2)]
+    (let [result (doc/search conn "people" "person" {:query (q/term :planet "earth") :size 2})]
       (is (any-hits? result))
       (is (= 2 (count (hits-from result))))
       ;; but total # of hits is reported w/o respect to the limit. MK.
       (is (= 4 (total-hits result)))))
 
   (deftest ^{:query true :native true} test-basic-term-query-with-tweets-mapping
-    (let [result (doc/search conn "tweets" "tweet" :query (q/term :text "improved"))]
+    (let [result (doc/search conn "tweets" "tweet" {:query (q/term :text "improved")})]
       (is (any-hits? result))
       (is (= fx/tweet1 (-> result hits-from first :_source)))))
 
   (deftest ^{:query true :native true} test-basic-terms-query-with-tweets-mapping
-    (let [result (doc/search conn "tweets" "tweet" :query (q/term :text ["supported" "improved"]))]
+    (let [result (doc/search conn "tweets" "tweet" {:query (q/term :text ["supported" "improved"])})]
       (is (any-hits? result))
       (is (= fx/tweet1 (-> result hits-from first :_source)))))
 
   (deftest ^{:query true :native true} test-basic-term-query-over-non-analyzed-usernames
-    (are [username id] (= id (-> (doc/search conn "tweets" "tweet" :query (q/term :username username) :sort {:timestamp "asc"})
+    (are [username id] (= id (-> (doc/search conn "tweets" "tweet" {:query (q/term :username username) :sort {:timestamp "asc"}})
                                      hits-from
                                      first
                                      :_id))
@@ -54,7 +54,7 @@
          "DEVOPS_BORAT"   "5"))
 
   (deftest ^{:query true :native true} test-basic-term-query-over-non-analyzed-embedded-fields
-    (are [state id] (= id (-> (doc/search conn "tweets" "tweet" :query (q/term "location.state" state) :sort {:timestamp "asc"})
+    (are [state id] (= id (-> (doc/search conn "tweets" "tweet" {:query (q/term "location.state" state) :sort {:timestamp "asc"}})
                                   hits-from
                                   first
                                   :_id))

--- a/test/clojurewerkz/elastisch/native_api/queries/wildcard_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/wildcard_query_test.clj
@@ -20,7 +20,7 @@
 
 (let [conn (th/connect-native-client)]
   (deftest ^{:query true :native true} test-trailing-wildcard-query-with-nested-fields
-    (let [response     (doc/search conn "articles" "article" :query (q/wildcard "latest-edit.author" "Thorw*"))
+    (let [response     (doc/search conn "articles" "article" {:query (q/wildcard {"latest-edit.author" "Thorw*"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))
@@ -28,7 +28,7 @@
 
 
   (deftest ^{:query true :native true} test-leading-wildcard-query-with-non-analyzd-field
-    (let [response     (doc/search conn "tweets" "tweet" :query (q/wildcard :username "*werkz"))
+    (let [response     (doc/search conn "tweets" "tweet" {:query (q/wildcard {:username "*werkz"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))

--- a/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_scroll_test.clj
@@ -23,13 +23,13 @@
     (let [index-name "articles"
           mapping-type "article"
           response (doc/search conn index-name mapping-type
-                               :query (q/match-all)
-                               :search_type "scan"
-                               :scroll "1m"
-                               :size 1)
+                               {:query (q/match-all)
+                                :search_type "scan"
+                                :scroll "1m"
+                                :size 1})
           initial-hits (hits-from response)
           scroll-id (:_scroll_id response)
-          scan-response (doc/scroll conn scroll-id :scroll "1m")
+          scan-response (doc/scroll conn scroll-id {:scroll "1m"})
           scan-hits (hits-from scan-response)]
       (is (any-hits? response))
       (is scroll-id)
@@ -41,20 +41,20 @@
     (let [index-name "articles"
           mapping-type "article"
           response (doc/search conn index-name mapping-type
-                               :query (q/match-all)
-                               :search_type "query_then_fetch"
-                               :scroll "1m"
-                               :size 2)
+                               {:query (q/match-all)
+                                :search_type "query_then_fetch"
+                                :scroll "1m"
+                                :size 2})
           initial-hits (hits-from response)
           scroll-id (:_scroll_id response)
-          scroll-response (doc/scroll conn scroll-id :scroll "1m")
+          scroll-response (doc/scroll conn scroll-id {:scroll "1m"})
           scroll-hits (hits-from scroll-response)]
       (is (= 4 (total-hits scroll-response)))
       (is (= 2 (count scroll-hits)))))
 
   (defn fetch-scroll-results
     [scroll-id results]
-    (let [scroll-response (doc/scroll conn scroll-id :scroll "1m")
+    (let [scroll-response (doc/scroll conn scroll-id {:scroll "1m"})
           hits (hits-from scroll-response)]
       (if (seq hits)
         (recur (:_scroll_id scroll-response) (concat results hits))
@@ -64,10 +64,10 @@
     (let [index-name "articles"
           mapping-type "article"
           response (doc/search conn index-name mapping-type
-                               :query (q/match-all)
-                               :search_type "query_then_fetch"
-                               :scroll "1m"
-                               :size 1)
+                               {:query (q/match-all)
+                                :search_type "query_then_fetch"
+                                :scroll "1m"
+                                :size 1})
           initial-hits (hits-from response)
           scroll-id (:_scroll_id response)
           all-hits (fetch-scroll-results scroll-id initial-hits)]
@@ -79,10 +79,10 @@
           mapping-type "article"
           res-seq (doc/scroll-seq conn
                                   (doc/search conn index-name mapping-type
-                                              :query (q/match-all)
-                                              :search_type "query_then_fetch"
-                                              :scroll "1m"
-                                              :size 2))]
+                                              {:query (q/match-all)
+                                               :search_type "query_then_fetch"
+                                               :scroll "1m"
+                                               :size 2}))]
       (is (= false (realized? res-seq)))
       (is (= 4 (count res-seq)))
       (is (= 4 (count (distinct res-seq))))
@@ -93,10 +93,10 @@
           mapping-type "article"
           res-seq (doc/scroll-seq conn
                                   (doc/search conn index-name mapping-type
-                                              :query (q/match-all)
-                                              :search_type "scan"
-                                              :scroll "1m"
-                                              :size 2)
+                                              {:query (q/match-all)
+                                               :search_type "scan"
+                                               :scroll "1m"
+                                               :size 2})
                                   {:search_type "scan"})]
       (is (= false (realized? res-seq)))
       (is (= 4 (count res-seq)))
@@ -108,10 +108,10 @@
           mapping-type "article"
           res-seq (doc/scroll-seq conn
                                   (doc/search conn index-name mapping-type
-                                              :query (q/term :title "Emptiness")
-                                              :search_type "query_then_fetch"
-                                              :scroll "1m"
-                                              :size 2))]
+                                              {:query (q/term :title "Emptiness")
+                                               :search_type "query_then_fetch"
+                                               :scroll "1m"
+                                               :size 2}))]
       (is (= 0 (count res-seq)))
       (is (coll? res-seq)))))
 

--- a/test/clojurewerkz/elastisch/native_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_test.clj
@@ -60,7 +60,7 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type {:query (q/match-all)
-                                   :sort (array-map "title" "desc")})
+                                                                 :sort (array-map "title" "desc")})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits first :_source :title)))
@@ -70,7 +70,7 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type {:query (q/match-all)
-                                   :sort (array-map "title" "asc")})
+                                                                 :sort (array-map "title" "asc")})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits last :_source :title)))

--- a/test/clojurewerkz/elastisch/native_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/search_test.clj
@@ -35,15 +35,15 @@
                                                     :planet     "Earth"
                                                     :age 42}))
         (idx/refresh conn index-name)
-        (let [result (doc/search conn index-name mapping-type :query (q/term :biography "say"))]
+        (let [result (doc/search conn index-name mapping-type {:query (q/term :biography "say")})]
           (is (= 1 (total-hits result)))))))
 
   (deftest ^{:native true} test-search-query-with-basic-filtering
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:term {:username "esmary"}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:term {:username "esmary"}}}))]
       (is (= 1 (count hits)))))
 
   (deftest ^{:native true} test-basic-sorting-over-string-field-with-implicit-order
@@ -59,8 +59,8 @@
   (deftest ^{:native true} test-basic-sorting-over-string-field-with-desc-order
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/match-all)
-                                   :sort (array-map "title" "desc"))
+          response     (doc/search conn index-name mapping-type {:query (q/match-all)
+                                   :sort (array-map "title" "desc")})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits first :_source :title)))
@@ -69,8 +69,8 @@
   (deftest ^{:native true} test-basic-sorting-over-string-field-with-asc-order
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/match-all)
-                                   :sort (array-map "title" "asc"))
+          response     (doc/search conn index-name mapping-type {:query (q/match-all)
+                                   :sort (array-map "title" "asc")})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits last :_source :title)))
@@ -80,8 +80,8 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :fields ["title"])
+                                   {:query (q/match-all)
+                                    :fields ["title"]})
           hits         (hits-from response)
           title-fields (remove nil? (map #(get-in % [:_fields :title]) hits))
           title-source (remove nil? (map #(get-in % [:_source :title]) hits))]
@@ -93,8 +93,8 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :fields ["title" "_source"])
+                                   {:query (q/match-all)
+                                    :fields ["title" "_source"]})
           hits         (hits-from response)
           title-fields (remove nil? (map #(get-in % [:_fields :title]) hits))
           title-source (remove nil? (map #(get-in % [:_source :title]) hits))]
@@ -106,9 +106,9 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    {"first-name" "asc"}
-                                              :_source ["first-name" "age"]))]
+                                              {:query   (q/match-all)
+                                               :sort    {"first-name" "asc"}
+                                               :_source ["first-name" "age"]}))]
       (is (= 4 (count hits)))
       (is (= {:first-name "Tony" :age 29} (-> hits last :_source)))))
 
@@ -116,11 +116,11 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    {"first-name" "asc"}
-                                              :_source {"exclude" ["title" "country"
-                                                                   "planet" "biography"
-                                                                   "last-name" "username"]}))]
+                                              {:query   (q/match-all)
+                                               :sort    {"first-name" "asc"}
+                                               :_source {"exclude" ["title" "country"
+                                                                    "planet" "biography"
+                                                                    "last-name" "username"]}}))]
       (is (= 4 (count hits)))
       (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source)))))))
 
@@ -128,18 +128,18 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    (q/sort "surname"
-                                                               {:order "asc"
-                                                                :ignore-unmapped true})))]
+                                              {:query   (q/match-all)
+                                               :sort    (q/sort "surname"
+                                                                {:order "asc"
+                                                                 :ignore-unmapped true})}))]
       (is (= 4 (count hits)))))
 
   (deftest ^{:native true} search-using-template-with-results
   (doc/create-search-template conn "test-template1" fx/test-template1)
   (doc/create conn "tweets" "tweet" fx/tweet1)
     (let [result (map :source (hits-from (doc/search conn "tweets" "tweet"
-                             :template {:id "test-template1"}
-                             :params {:username "clojurewerkz"})))]
+                             {:template {:id "test-template1"}
+                              :params {:username "clojurewerkz"}})))]
   (is (= 1 (count result)))))
 
 
@@ -148,6 +148,6 @@
   (doc/create-search-template conn "test-template1" fx/test-template1)
   (doc/create conn "tweets" "tweet" fx/tweet1)
     (let [result (map :source (hits-from (doc/search conn "tweets" "tweet"
-                             :template {:id "test-template1"}
-                             :params {:username "returns nothing"})))]
+                             {:template {:id "test-template1"}
+                              :params {:username "returns nothing"}})))]
   (is (empty?  result)))))

--- a/test/clojurewerkz/elastisch/native_api/update_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/update_test.clj
@@ -25,41 +25,41 @@
           index-type "person"
           id         "3"
           new-bio    "Such a brilliant person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
       (doc/put conn index-name index-type "1" fx/person-jack)
       (doc/put conn index-name index-type "2" fx/person-mary)
       (doc/put conn index-name index-type "3" fx/person-joe)
 
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name index-type :query (q/term :biography "nice"))))
-      (is (no-hits?  (doc/search conn index-name index-type :query (q/term :biography "brilliant"))))
+      (is (any-hits? (doc/search conn index-name index-type {:query (q/term :biography "nice")})))
+      (is (no-hits?  (doc/search conn index-name index-type {:query (q/term :biography "brilliant")})))
       (doc/replace conn index-name index-type id (assoc fx/person-joe :biography new-bio))
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name index-type :query (q/term :biography "brilliant"))))
-      (is (no-hits? (doc/search conn index-name index-type :query (q/term :biography "nice"))))))
+      (is (any-hits? (doc/search conn index-name index-type {:query (q/term :biography "brilliant")})))
+      (is (no-hits? (doc/search conn index-name index-type {:query (q/term :biography "nice")})))))
 
   (deftest test-versioning
     (let [index-name "people"
           index-type "person"
           id         "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
-      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") :id id)
+      (idx/create conn index-name {:mappings fx/people-mapping})
+      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") {:id id})
       (idx/refresh conn index-name)
       (let [original-document (doc/get conn index-name index-type id)
             original-version (:_version original-document)]
-        (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant2") :version original-version)
+        (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant2") {:version original-version})
         (is (= "brilliant2" (get-in (doc/get conn index-name index-type id) [:_source :biography])))
                                         ; Can't perform a write when we pass the wrong version
-        (is (thrown? VersionConflictEngineException (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant3") :version original-version)))
+        (is (thrown? VersionConflictEngineException (doc/put conn index-name index-type id (assoc fx/person-jack :biography "brilliant3") {:version original-version})))
         (is (= "brilliant2" (get-in (doc/get conn index-name index-type id) [:_source :biography]))))))
 
   (deftest test-retry-on-conflict
     (let [index-name "people"
           index-type "person"
           id         "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
-      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") :id id)
+      (idx/create conn index-name {:mappings fx/people-mapping})
+      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") {:id id})
       (idx/refresh conn index-name)
       (let [original-document (doc/get conn index-name index-type id)
             original-version (:_version original-document)]
@@ -74,8 +74,8 @@
     (let [index-name "people"
           index-type "person"
           id         "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
-      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") :id id)
+      (idx/create conn index-name {:mappings fx/people-mapping})
+      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") {:id id})
       (idx/refresh conn index-name)
       (let [original-document (doc/get conn index-name index-type id)]
         (doc/update-with-partial-doc conn index-name index-type id {:country "Sweden"})
@@ -105,9 +105,9 @@
     (let [index-name "people"
           index-type "person"
           id "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
-      (doc/create conn index-name index-type fx/person-jack :id id)
+      (doc/create conn index-name index-type fx/person-jack {:id id})
 
       (idx/refresh conn index-name)
 
@@ -133,7 +133,7 @@
       (testing "update with groovy script no params"
         (let [orig (doc/get conn index-name index-type id)]
           (doc/update-with-script conn index-name index-type id
-                                  "ctx._source.age = ctx._source.age += 1" {} :lang "groovy")
+                                  "ctx._source.age = ctx._source.age += 1" {} {:lang "groovy"})
           (idx/refresh conn index-name)
           (is (= (-> orig :_source :age inc)
                  (-> (doc/get conn index-name index-type id) :_source  :age))))))))

--- a/test/clojurewerkz/elastisch/native_api/upsert_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/upsert_test.clj
@@ -24,19 +24,19 @@
           index-type "person"
           id         "3"
           new-bio    "Such a brilliant person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
       (doc/put conn index-name index-type "1" fx/person-jack)
       (doc/put conn index-name index-type "2" fx/person-mary)
       (doc/put conn index-name index-type "3" fx/person-joe)
 
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name index-type :query (q/term :biography "nice"))))
-      (is (no-hits?  (doc/search conn index-name index-type :query (q/term :biography "brilliant"))))
+      (is (any-hits? (doc/search conn index-name index-type {:query (q/term :biography "nice")})))
+      (is (no-hits?  (doc/search conn index-name index-type {:query (q/term :biography "brilliant")})))
       (doc/upsert conn index-name index-type id (assoc fx/person-joe :biography new-bio))
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name index-type :query (q/term :biography "brilliant"))))
-      (is (no-hits?  (doc/search conn index-name index-type :query (q/term :biography "nice"))))))
+      (is (any-hits? (doc/search conn index-name index-type {:query (q/term :biography "brilliant")})))
+      (is (no-hits?  (doc/search conn index-name index-type {:query (q/term :biography "nice")})))))
 
   (deftest test-upserting-document-with-parent
     (let [index-name "people"
@@ -45,8 +45,8 @@
           child-index-type "passport"
           id         "3"
           new-bio    "Such a brilliant person"]
-      (idx/create conn index-name  :mappings fx/people-mapping)
-      (idx/create conn child-index-name :mappings fx/passport-mapping)
+      (idx/create conn index-name  {:mappings fx/people-mapping})
+      (idx/create conn child-index-name {:mappings fx/passport-mapping})
       (doc/put conn index-name index-type "1" fx/person-jack)
       (doc/upsert conn child-index-name child-index-type "123000456000" {"id" "123000456000"} {:parent "1"})))
 
@@ -55,7 +55,7 @@
           index-type "person"
           id         "3"
           new-bio    "Such a brilliant person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/put conn index-name index-type "1" fx/person-jack)
       (is (no-hits?  (doc/search conn index-name index-type {:query (q/term :biography "nice")})))
       (is (no-hits?  (doc/search conn index-name index-type {:query (q/term :biography "brilliant")})))

--- a/test/clojurewerkz/elastisch/query_test.clj
+++ b/test/clojurewerkz/elastisch/query_test.clj
@@ -18,7 +18,7 @@
     (is (= expected (query/term :foo "bar"))))
 
   (let [expected {:term {:foo :bar} :minimum_match 2}]
-    (is (= expected (query/term :foo :bar :minimum_match 2)))))
+    (is (= expected (query/term :foo :bar {:minimum_match 2})))))
 
 (deftest terms-query-test
   (let [expected {:terms {:foo [:bar :baz]}}]
@@ -26,7 +26,7 @@
 
 (deftest range-query-test
   (is (= {:range {:foo {:gt 5 :lt 10 :include_upper false :include_lower false}}}
-         (query/range :foo :gt 5 :lt 10 :include_upper false :include_lower false))))
+         (query/range :foo {:gt 5 :lt 10 :include_upper false :include_lower false}))))
 
 (deftest bool-query-test
   (let [must                         {:term {:user  "kimchy"}}
@@ -36,11 +36,11 @@
         boost                        1.0
 
         result                       (query/bool
-                                      :must (query/term :user "kimchy")
-                                      :must_not (query/range :age :from 10 :to 20)
-                                      :should [(query/term :tag "wow") (query/term :tag "elasticsearch")]
-                                      :minimum_number_should_match 1
-                                      :boost 1.0)
+                                      {:must (query/term :user "kimchy")
+                                       :must_not (query/range :age {:from 10 :to 20})
+                                       :should [(query/term :tag "wow") (query/term :tag "elasticsearch")]
+                                       :minimum_number_should_match 1
+                                       :boost 1.0})
         bool                         (:bool result)]
     (are [actual expected] (= actual expected)
          must (:must bool)
@@ -55,10 +55,10 @@
         positive-boost 1.0
         negative-boost 0.2
         result         (query/boosting
-                        :positive (query/term :field1 "value1")
-                        :negative (query/term :field2 "value2")
-                        :positive_boost 1.0
-                        :negative_boost 0.2)
+                        {:positive (query/term :field1 "value1")
+                         :negative (query/term :field2 "value2")
+                         :positive_boost 1.0
+                         :negative_boost 0.2})
         boosting       (:boosting result)]
 
     (are [actual expected] (= actual expected)
@@ -75,8 +75,8 @@
   (let [query   {:terms {:foo [:bar :baz]}}
         boost   2.0
         result  (query/constant-score
-                 :query   (query/term :foo [:bar :baz])
-                 :boost   boost)
+                 {:query   (query/term :foo [:bar :baz])
+                  :boost   boost})
         constant-score (:constant_score result)]
     (are [actual expected] (= actual expected)
          query    (:query constant-score)
@@ -88,9 +88,9 @@
         boost       2.0
         tie-breaker 0.7
         result  (query/dis-max
-                 :queries     [query1 query2]
-                 :boost       boost
-                 :tie_breaker tie-breaker)
+                 {:queries     [query1 query2]
+                  :boost       boost
+                  :tie_breaker tie-breaker})
         dis-max  (:dis_max result)]
     (are [actual expected] (= actual expected)
          query1   (first  (:queries dis-max))
@@ -102,8 +102,8 @@
   (deftest query-string-test
     (let [raw-query "+ - && & || | ! ( ) { } [ ] ^ \" ~ * ? : \\"
           escaped-query "\\+ \\- \\&& & \\|| | \\! \\( \\) \\{ \\} \\[ \\] \\^ \\\" \\~ \\* \\? \\: \\\\"
-          result-with-default-escaping (query/query-string :query raw-query)
-          result-with-explicit-escape-fn (query/query-string :query raw-query :escape-with identity)]
+          result-with-default-escaping (query/query-string {:query raw-query})
+          result-with-explicit-escape-fn (query/query-string {:query raw-query :escape-with identity})]
       (is (= escaped-query
              (get-in result-with-default-escaping [:query_string :query])))
       (is (= raw-query

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/avg_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/avg_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:avg_age (a/avg "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:avg_age (a/avg "age")}})
           agg          (aggregation-from response :avg_age)]
       (is (= {:value 29.0} agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/cardinality_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/cardinality_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:username_count {:cardinality {:field "username"}}})
+                                   {:query (q/match-all)
+                                    :aggregations {:username_count {:cardinality {:field "username"}}}})
           agg          (aggregation-from response :username_count)]
       (is (>= (:value agg) 4)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/date_histogram_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/date_histogram_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/date-histogram "signed_up_at" "1d")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/date-histogram "signed_up_at" "1d")}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/date_range_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/date_range_aggregation_test.clj
@@ -23,10 +23,10 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/date-range "signed_up_at"
-                                                                            "date_hour_minute_second"
-                                                                            [{:from "2012-02-01T00:00:00" :to "2012-02-29T23:59:59"}
-                                                                             {:from "2012-03-01T00:00:00"}])})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/date-range "signed_up_at"
+                                                                             "date_hour_minute_second"
+                                                                             [{:from "2012-02-01T00:00:00" :to  "2012-02-29T23:59:59"}
+                                                                              {:from "2012-03-01T00:00:00"}])}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/extended_stats_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/extended_stats_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_stats (a/extended-stats "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_stats (a/extended-stats "age")}})
           agg          (aggregation-from response :age_stats)
           keys         (set (keys agg))]
       (doseq [k #{:count :min :max :avg :sum :std_deviation :sum_of_squares :variance}]

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/histogram_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/histogram_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_histograms (a/histogram "age" 5)})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_histograms (a/histogram "age" 5)}})
           agg          (aggregation-from response :age_histograms)]
       (is (:buckets agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/max_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/max_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:max_age (a/max "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:max_age (a/max "age")}})
           agg          (aggregation-from response :max_age)]
       (is (= {:value 37.0} agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/min_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/min_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:min_age (a/min "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:min_age (a/min "age")}})
           agg          (aggregation-from response :min_age)]
       (is (= {:value 22.0} agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/missing_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/missing_aggregation_test.clj
@@ -23,7 +23,7 @@
   (let [index-name   "people"
         mapping-type "person"
         response     (doc/search conn index-name mapping-type
-                                 :query (q/match-all)
-                                 :aggregations {:no_country (a/missing :country)})
+                                 {:query (q/match-all)
+                                  :aggregations {:no_country (a/missing :country)}})
         agg          (aggregation-from response :no_country)]
     (is (>= (:doc_count agg) 3)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/percentiles_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/percentiles_aggregation_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:percentiles_age (a/percentiles "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:percentiles_age (a/percentiles "age")}})
           agg          (aggregation-from response :percentiles_age)]
       (is (= #{:1.0 :5.0 :25.0 :50.0 :75.0 :95.0 :99.0}
              (set (keys (get agg :values))))))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/range_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/range_aggregation_test.clj
@@ -23,10 +23,10 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_ranges (a/range "age" [{:from 15 :to 20}
-                                                                              {:from 21 :to 25}
-                                                                              {:from 26 :to 30}
-                                                                              {:from 31}])})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_ranges (a/range "age" [{:from 15 :to 20}
+                                                                               {:from 21 :to 25}
+                                                                               {:from 26 :to 30}
+                                                                               {:from 31}])}})
           agg          (aggregation-from response :age_ranges)]
       (is (:buckets agg)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/stats_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/stats_aggregation_test.clj
@@ -24,7 +24,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:age_stats (a/stats "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:age_stats (a/stats "age")}})
           agg          (aggregation-from response :age_stats)]
       (is (= #{:count :min :max :avg :sum} (set (keys agg)))))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/sum_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/sum_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:sum_age (a/sum "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:sum_age (a/sum "age")}})
           agg          (aggregation-from response :sum_age)]
       (is (>= (:value agg) 116)))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/terms_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/terms_aggregation_test.clj
@@ -23,7 +23,7 @@
   (let [index-name   "people"
         mapping-type "person"
         response     (doc/search conn index-name mapping-type
-                                 :query (q/match-all)
-                                 :aggregations {:title_terms (a/terms "title")})
+                                 {:query (q/match-all)
+                                  :aggregations {:title_terms (a/terms "title")}})
         agg          (aggregation-from response :title_terms)]
     (is (= 6 (count (:buckets agg)))))))

--- a/test/clojurewerkz/elastisch/rest_api/aggregations/value_count_aggregation_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/aggregations/value_count_aggregation_test.clj
@@ -23,7 +23,7 @@
     (let [index-name   "people"
           mapping-type "person"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :aggregations {:agg1 (a/value-count "age")})
+                                   {:query (q/match-all)
+                                    :aggregations {:agg1 (a/value-count "age")}})
           agg          (aggregation-from response :agg1)]
       (is (>= (:value agg) 4)))))

--- a/test/clojurewerkz/elastisch/rest_api/analyze_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/analyze_test.clj
@@ -52,7 +52,7 @@
               :end_offset 11,
               :type "word",
               :position 1}]}
-           (doc/analyze conn "foo bar-baz" :analyzer "whitespace"))))
+           (doc/analyze conn "foo bar-baz" {:analyzer "whitespace"}))))
 
   (deftest ^{:rest true} test-analyze-with-map-options
     (is (= {:tokens

--- a/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/bulk_test.clj
@@ -54,7 +54,7 @@
   (deftest ^{:rest true :indexing true} test-bulk-with-index-and-type
     (let [document          fx/person-jack
           insert-operations (bulk/bulk-index (repeat 10 document))
-          response          (bulk/bulk-with-index-and-type conn index-name index-type insert-operations :refresh true)
+          response          (bulk/bulk-with-index-and-type conn index-name index-type insert-operations {:refresh true})
           first-id          (-> response :items first :create :_id)
           get-result        (doc/get conn index-name index-type first-id)]
       (are-all-successful (->> response :items (map :create)))
@@ -71,7 +71,7 @@
           response        (bulk/bulk-with-index-and-type conn index-name index-type insert-ops {:refresh true})
           docs            (->> response :items (map :create) )
           initial-count   (:count (doc/count conn index-name index-type))
-          delete-response (bulk/bulk-with-index-and-type conn index-name index-type (bulk/bulk-delete docs) :refresh true)]
+          delete-response (bulk/bulk-with-index-and-type conn index-name index-type (bulk/bulk-delete docs) {:refresh true})]
       (is (= 10 initial-count))
       (are-all-successful (->> response :items (map :create)))
       (is (= 0 (:count (doc/count conn index-name index-type))))))

--- a/test/clojurewerkz/elastisch/rest_api/cluster_health_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/cluster_health_test.clj
@@ -19,9 +19,9 @@
   (deftest ^{:rest true} cluster-health
   (let [r (admin/cluster-health conn)]
     (is (contains? r :number_of_nodes)))
-  (let [r (admin/cluster-health conn :index "tweets")]
+  (let [r (admin/cluster-health conn {:index "tweets"})]
     (is (contains? r :number_of_nodes)))
-  (let [r (admin/cluster-health conn :index ["tweets" "people"])]
+  (let [r (admin/cluster-health conn {:index ["tweets" "people"]})]
     (is (contains? r :number_of_nodes)))
   (let [r (admin/cluster-health conn {:index ["tweets"] :level "shards"})]
     (is (contains? r :number_of_nodes)))))

--- a/test/clojurewerkz/elastisch/rest_api/count_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/count_test.clj
@@ -26,7 +26,7 @@
   (deftest ^{:rest true} test-count-with-the-default-query
   (let [index-name "people"
         index-type "person"]
-    (idx/create conn index-name :mappings fx/people-mapping)
+    (idx/create conn index-name {:mappings fx/people-mapping})
     (doc/create conn index-name index-type fx/person-jack)
     (doc/create conn index-name index-type fx/person-joe)
     (idx/refresh conn index-name)
@@ -36,7 +36,7 @@
   (deftest ^{:rest true} test-count-with-a-term-query
     (let [index-name "people"
           index-type "person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/create conn index-name index-type fx/person-jack)
       (doc/create conn index-name index-type fx/person-joe)
       (idx/refresh conn index-name)

--- a/test/clojurewerkz/elastisch/rest_api/document_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/document_test.clj
@@ -28,6 +28,6 @@
       (testing "that the functions that default to throwing exceptions can be configured to swallow them"
         (is (thrown-with-msg? ExceptionInfo
                               #"clj-http: status 400"
-                              (es.document/create default-conn index mapping doc :id id)))
-        (is (= (es.document/create no-throwing-conn index mapping doc :id id)
+                              (es.document/create default-conn index mapping doc {:id id})))
+        (is (= (es.document/create no-throwing-conn index mapping doc {:id id})
                {:error "This is an example exception.", :status 400}))))))

--- a/test/clojurewerkz/elastisch/rest_api/filtering_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/filtering_test.clj
@@ -23,8 +23,8 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:term {:username "esmary"}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:term {:username "esmary"}}}))]
       (is (= 1 (count hits)))
       (is (= "Lindey" (-> hits first :_source :last-name)))))
 
@@ -32,7 +32,7 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:range {:age {:from 26 :to 30}}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:range {:age {:from 26 :to 30}}}}))]
       (is (= 2 (count hits)))
       (is (#{28 29} (-> hits first :_source :age))))))

--- a/test/clojurewerkz/elastisch/rest_api/highlighting_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/highlighting_test.clj
@@ -23,14 +23,14 @@
   (deftest ^{:rest true} test-highlighting-with-all-defaults
     (let [index "articles"
           type  "article"]
-      (idx/create conn index :mappings fx/articles-mapping)
+      (idx/create conn index {:mappings fx/articles-mapping})
       (doc/put conn index type "1" fx/article-on-elasticsearch)
       (doc/put conn index type "2" fx/article-on-lucene)
       (doc/put conn index type "3" fx/article-on-nueva-york)
       (doc/put conn index type "4" fx/article-on-austin)
       (idx/refresh conn index)
       (let [resp  (doc/search conn index type
-                              {:query (q/query-string :query "software" :default_field "summary")
+                              {:query (q/query-string {:query "software" :default_field "summary"})
                                :highlight {:fields {:summary {}}}})
             hits  (hits-from resp)]
         (is (re-find #"<em>software</em>" (-> hits first :highlight :summary first)))))))

--- a/test/clojurewerkz/elastisch/rest_api/indexing_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/indexing_test.clj
@@ -80,46 +80,46 @@
 
   (deftest ^{:rest true :indexing true} test-put-with-new-document-version
     (let [id       "1"
-          _        (doc/put conn index-name index-type id fx/person-jack :version 1 :version_type "external")
-          _        (doc/put conn index-name index-type id fx/person-mary :version 2 :version_type "external")
-          response (doc/put conn index-name index-type id fx/person-joe  :version 3 :version_type "external")]
+          _        (doc/put conn index-name index-type id fx/person-jack {:version 1 :version_type "external"})
+          _        (doc/put conn index-name index-type id fx/person-mary {:version 2 :version_type "external"})
+          response (doc/put conn index-name index-type id fx/person-joe  {:version 3 :version_type "external"})]
       (is (not (conflict? response)))
       (is (= 3 (:_version response)))))
 
   (deftest ^{:rest true :indexing true} create-when-already-created-test
     (let [id       "1"
           _        (doc/put conn index-name index-type id fx/person-jack)
-          response (doc/put conn index-name index-type id fx/person-joe :op_type "create")]
+          response (doc/put conn index-name index-type id fx/person-joe {:op_type "create"})]
       (is (conflict? response))))
 
   (deftest ^{:rest true :indexing true} test-put-with-a-timestamp
     (let [id       "1"
-          _        (idx/create conn index-name :mappings fx/people-mapping)
+          _        (idx/create conn index-name {:mappings fx/people-mapping})
           response (doc/put conn index-name index-type id fx/person-jack {:timestamp (-> 2 months ago)})]
       (is (created? response))))
 
   (deftest ^{:rest true :indexing true} test-put-with-a-1-day-ttl
     (let [id       "1"
-          _        (idx/create conn index-name :mappings fx/people-mapping)
-          response (doc/put conn index-name index-type id fx/person-jack :ttl "1d")]
+          _        (idx/create conn index-name {:mappings fx/people-mapping})
+          response (doc/put conn index-name index-type id fx/person-jack {:ttl "1d"})]  ; TODO ttl is deprecated
       (is (created? response))))
 
   (deftest ^{:rest true :indexing true} test-put-with-a-10-seconds-ttl
     (let [id       "1"
-          _        (idx/create conn index-name :mappings fx/people-mapping)
-          response (doc/put conn index-name index-type id fx/person-jack :ttl "10000ms")]
+          _        (idx/create conn index-name {:mappings fx/people-mapping})
+          response (doc/put conn index-name index-type id fx/person-jack {:ttl "10000ms"})]  ; TODO ttl is deprecated
       (is (created? response))))
 
   (deftest ^{:rest true :indexing true} test-put-with-a-timeout
     (let [id       "1"
-          _        (idx/create conn index-name :mappings fx/people-mapping)
-          response (doc/put conn index-name index-type id fx/person-jack :timeout "1m")]
+          _        (idx/create conn index-name {:mappings fx/people-mapping})
+          response (doc/put conn index-name index-type id fx/person-jack {:timeout "1m"})]
       (is (created? response))))
 
   (deftest ^{:rest true :indexing true} test-put-with-refresh-set-to-true
     (let [id       "1"
-          _        (idx/create conn index-name :mappings fx/people-mapping)
-          response (doc/put conn index-name index-type id fx/person-jack :refresh true)]
+          _        (idx/create conn index-name {:mappings fx/people-mapping})
+          response (doc/put conn index-name index-type id fx/person-jack {:refresh true})]
       (is (created? response))))
 
   (deftest ^{:rest true :indexing true} test-put-create-autogenerate-id-test
@@ -133,13 +133,13 @@
 
   (deftest ^{:rest true :indexing true} test-a-custom-analyzer-and-stop-word-list
     (is (acknowledged? (idx/create conn "alt-tweets"
-                                   :settings {:index {:analysis {:analyzer {:antiposers {:type      "standard"
-                                                                                         :filter    ["standard" "lowercase" "stop"]
-                                                                                         :stopwords ["lol" "rockstar" "ninja" "cloud" "event"]}}}}}
-                                   :mappings {:tweet {:properties {:text {:type "string" :analyzer "antiposers"}}}})))
+                                   {:settings {:index {:analysis {:analyzer {:antiposers {:type      "standard"
+                                                                                          :filter    ["standard" "lowercase" "stop"]
+                                                                                          :stopwords ["lol" "rockstar" "ninja" "cloud" "event"]}}}}}
+                                    :mappings {:tweet {:properties {:text {:type "string" :analyzer "antiposers"}}}}})))
     (is (created? (doc/create conn "alt-tweets" "tweet" {:text "I am a ninja rockstar brogrammer, yo. I like that event-driven thing."})))
     (idx/refresh conn "alt-tweets")
-    (let [r1 (doc/search conn "alt-tweets" "tweet" :query (q/query-string :query "text:event-driven" :default_field :text))
-          r2 (doc/search conn "alt-tweets" "tweet" :query (q/query-string :query "text:(rockstar OR ninja)" :default_field :text))]
+    (let [r1 (doc/search conn "alt-tweets" "tweet" {:query (q/query-string {:query "text:event-driven" :default_field :text})})
+          r2 (doc/search conn "alt-tweets" "tweet" {:query (q/query-string {:query "text:(rockstar OR ninja)" :default_field :text})})]
       (is (any-hits? r1))
       (is (no-hits? r2)))))

--- a/test/clojurewerkz/elastisch/rest_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/indices_test.clj
@@ -24,18 +24,18 @@
       (is (not (idx/type-exists? conn "elastisch-index-without-mappings" "person")))))
 
   (deftest ^{:rest true :indexing true} test-create-an-index-with-settings
-    (let [response (idx/create conn "elastisch-index-without-mappings" :settings {"index" {"number_of_shards" 1}})]
+    (let [response (idx/create conn "elastisch-index-without-mappings" {:settings {"index" {"number_of_shards" 1}}})]
       (is (acknowledged? response))))
 
   (deftest ^{:rest true :indexing true} test-successful-creation-of-index-with-mappings-and-without-settings
     (let [index    "people"
-          response (idx/create conn index :mappings fx/people-mapping)]
+          response (idx/create conn index {:mappings fx/people-mapping})]
       (is (idx/exists? conn index))
       (is (idx/type-exists? conn index "person"))))
 
   (deftest ^{:rest true :indexing true} test-successful-deletion-of-index
     (let [index    "people"
-          _        (idx/create conn index :mappings fx/people-mapping)
+          _        (idx/create conn index {:mappings fx/people-mapping})
           response (idx/delete conn index)]
       (is (not (idx/exists? conn index)))
       (is (not (idx/type-exists? conn index "person")))))
@@ -43,7 +43,7 @@
   (deftest ^{:rest true :indexing true} test-getting-index-settings
     (let [index     "people"
           settings  {:index {:refresh_interval "1s"}}
-          response  (idx/create conn index :settings settings :mappings fx/people-mapping)
+          response  (idx/create conn index {:settings settings :mappings fx/people-mapping})
           settings' (idx/get-settings conn "people")]
       (acknowledged? response)
       (is (= "1s" (get-in settings' [:people :settings :index :refresh_interval])))))
@@ -51,7 +51,7 @@
   (deftest ^{:rest true :indexing true} testing-updating-specific-index-settings
     (let [index     "people"
           settings  { :index { :refresh_interval "7s" } }
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           response  (idx/update-settings conn index settings)
           settings' (idx/get-settings conn "people")]
       (acknowledged? response)
@@ -59,25 +59,25 @@
 
   (deftest ^{:rest true :indexing true} test-optimize-index
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/optimize conn index :only_expunge_deletes 1)]
+          _         (idx/create conn index {:mappings fx/people-mapping})
+          response  (idx/optimize conn index {:only_expunge_deletes 1})]
       (is (:_shards response))))
 
   (deftest ^{:rest true :indexing true} test-flush-index-with-refresh
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/flush conn index :refresh true)]
+          _         (idx/create conn index {:mappings fx/people-mapping})
+          response  (idx/flush conn index {:refresh true})]
       (is (:_shards response))))
 
   (deftest ^{:rest true :indexing true} test-clear-index-cache-with-refresh
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
-          response  (idx/clear-cache conn index :filter true :field_data true)]
+          _         (idx/create conn index {:mappings fx/people-mapping})
+          response  (idx/clear-cache conn index {:filter true :field_data true})]
       (is (:_shards response))))
 
   (deftest ^{:rest true :indexing true} test-index-recovery-1
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           response  (idx/recovery conn index)]
       (is (get-in response [:people :shards]))))
 
@@ -92,7 +92,7 @@
 
   (deftest ^{:rest true :indexing true} test-index-status-2
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           response  (idx/segments conn index)]
       (is (:_shards response))))
 
@@ -104,9 +104,9 @@
 
   (deftest ^{:rest true :indexing true} test-index-stats
     (let [index     "people"
-          _         (idx/create conn index :mappings fx/people-mapping)
+          _         (idx/create conn index {:mappings fx/people-mapping})
           _         (idx/refresh conn index) ;; let's wait until ES has finished indexing
-          response  (idx/stats conn index :stats ["docs" "store" "indexing"] :types "person")
+          response  (idx/stats conn index {:stats ["docs" "store" "indexing"] :types "person"})
           stats     (-> response :_all :primaries)]
       (acknowledged? response)
       (is (every? #(contains? stats %) [:docs :store :indexing]))
@@ -115,13 +115,13 @@
   (deftest ^{:rest true :indexing true} test-index-stats-for-multiple-indexes
     (idx/create conn "group1")
     (idx/create conn "group2")
-    (let [response (idx/stats conn ["group1" "group2"] :stats ["docs" "store" "indexing"])
+    (let [response (idx/stats conn ["group1" "group2"] {:stats ["docs" "store" "indexing"]})
           stats (-> response :_all :primaries)]
       (is (every? #(contains? stats %) [:docs :store :indexing]))
       (is (not-any? #(contains? stats %) [:get :search :completion :fielddata :flush :merge :query_cache :refresh :suggest :warmer :translog]))))
 
   (deftest ^{:rest true :indexing true} test-create-an-index-with-two-aliases
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (let [response (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}
                                              {:add {:index "aliased-index" :alias "alias2"}}])]
       (acknowledged? response))
@@ -130,7 +130,7 @@
 
 
   (deftest ^{:rest true :indexing true} test-getting-aliases
-    (idx/create conn "aliased-index" :settings {"index" {"refresh_interval" "42s"}})
+    (idx/create conn "aliased-index" {:settings {"index" {"refresh_interval" "42s"}}})
     (let [res1 (idx/update-aliases conn [{:add {:index "aliased-index" :alias "alias1"}}
                                          {:add {:index "aliased-index" :alias "alias2" :routing 1}}])
           res2 (idx/get-aliases conn "aliased-index")]
@@ -138,18 +138,18 @@
       (is (get-in res2 [:aliased-index :aliases]))))
 
   (deftest ^{:rest true :indexing true} test-create-an-index-template-and-fetch-it
-    (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})
+    (idx/create-template conn "accounts" {:template "account*" :settings {:index {:refresh_interval "60s"}}})
     (let [res (idx/get-template conn "accounts")]
       (is (= "account*" (get-in res [:accounts :template])))
       (is (get-in res [:accounts :settings]))))
 
   (deftest ^{:rest true :indexing true} test-create-an-index-template-with-alias-and-fetch-it
-    (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}} :aliases { :account-alias {} })
+    (idx/create-template conn "accounts" {:template "account*" :settings {:index {:refresh_interval "60s"}} :aliases { :account-alias {} }})
     (let [res (idx/get-template conn "accounts")]
       (is (= "account*" (get-in res [:accounts :template])))
       (is (get-in res [:accounts :settings]))
       (is (get-in res [:accounts :aliases :account-alias]))))
 
   (deftest ^{:rest true :indexing true} test-create-an-index-template-and-delete-it
-    (idx/create-template conn "accounts" :template "account*" :settings {:index {:refresh_interval "60s"}})
+    (idx/create-template conn "accounts" {:template "account*" :settings {:index {:refresh_interval "60s"}}})
     (acknowledged? (idx/delete-template conn "accounts"))))

--- a/test/clojurewerkz/elastisch/rest_api/mappings_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/mappings_test.clj
@@ -20,7 +20,7 @@
   (deftest ^{:rest true} test-getting-index-mapping
     (let [index    "people1"
           mappings fx/people-mapping
-          response (idx/create conn index :mappings mappings)]
+          response (idx/create conn index {:mappings mappings})]
       (is (created-or-acknowledged? response))
       (is (get-in (idx/get-mapping conn index) [:people1 :mappings :person :properties :username :store]))))
 
@@ -28,8 +28,8 @@
     (let [index    "people2"
           mapping2 {:person {:properties {:first-name {:type "string" :store "yes"}}}}
           mapping  fx/people-mapping
-          _        (idx/create conn index :mappings mapping2)
-          response (idx/update-mapping conn index "person" :mapping mapping)]
+          _        (idx/create conn index {:mappings mapping2})
+          response (idx/update-mapping conn index "person" {:mapping mapping})]
       (is (created-or-acknowledged? response))))
 
   (deftest ^{:rest true} test-updating-blank-index-mapping

--- a/test/clojurewerkz/elastisch/rest_api/more_like_this_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/more_like_this_test.clj
@@ -23,17 +23,17 @@
   (deftest ^{:rest true} test-more-like-this
     (let [index "articles"
           type  "article"]
-      (idx/create conn index :mappings fx/articles-mapping)
+      (idx/create conn index {:mappings fx/articles-mapping})
       (doc/put conn index type "1" fx/article-on-elasticsearch)
       (doc/put conn index type "2" fx/article-on-lucene)
       (doc/put conn index type "3" fx/article-on-nueva-york)
       (doc/put conn index type "4" fx/article-on-austin)
       (idx/refresh conn index)
       (let [response (doc/more-like-this conn index type
-                                         :ids ["2"]
-                                         :fields ["tags"]
-                                         :min_term_freq 1
-                                         :min_doc_freq 1)]
+                                         {:ids ["2"]
+                                          :fields ["tags"]
+                                          :min_term_freq 1
+                                          :min_doc_freq 1})]
         (is (= 1 (total-hits response)))
         (is (= fx/article-on-elasticsearch
                (-> (hits-from response) first :_source)))))))

--- a/test/clojurewerkz/elastisch/rest_api/multi_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/multi_test.clj
@@ -35,8 +35,8 @@
              (-> multires second :hits :hits first :_source)))))
 
   (deftest ^{:rest true} test-multi-with-index-and-type
-    (let [res1 (doc/search conn "people" "person" :query (q/term :planet "earth"))
-          res2 (doc/search conn "people" "person" :query (q/term :first-name "mary"))
+    (let [res1 (doc/search conn "people" "person" {:query (q/term :planet "earth")})
+          res2 (doc/search conn "people" "person" {:query (q/term :first-name "mary")})
           multires (multi/search-with-index-and-type conn
                                                      "people" "person"
                                                      [{} {:query (q/term :planet "earth")}

--- a/test/clojurewerkz/elastisch/rest_api/nodes_info_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/nodes_info_test.clj
@@ -25,10 +25,10 @@
       (let [info (admin/nodes-info conn)
             node-id (first (keys (:nodes info)))
             node-name (get-in info [:nodes node-id :name])]
-        (is (empty? (:nodes (admin/nodes-info conn :nodes ["foo"]))))
-        (is (= 1 (count (:nodes (admin/nodes-info conn :nodes (name node-id))))))
-        (is (= 1 (count (:nodes (admin/nodes-info conn :nodes (vector (name node-id)))))))
-        (is (= 1 (count (:nodes (admin/nodes-info conn :nodes node-name)))))))
+        (is (empty? (:nodes (admin/nodes-info conn {:nodes ["foo"]}))))
+        (is (= 1 (count (:nodes (admin/nodes-info conn {:nodes (name node-id)})))))
+        (is (= 1 (count (:nodes (admin/nodes-info conn {:nodes (vector (name node-id))})))))
+        (is (= 1 (count (:nodes (admin/nodes-info conn {:nodes node-name})))))))
     (testing "parameters"
-      (is (not (= (admin/nodes-info conn :attributes ["plugins"])
-                  (admin/nodes-info conn :attributes ["os"])))))))
+      (is (not (= (admin/nodes-info conn {:attributes ["plugins"]})
+                  (admin/nodes-info conn {:attributes ["os"]})))))))

--- a/test/clojurewerkz/elastisch/rest_api/nodes_stats_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/nodes_stats_test.clj
@@ -23,10 +23,10 @@
     (let [stats (admin/nodes-stats conn)
           node-id (first (keys (:nodes stats))) 
           node-name (get-in stats [:nodes node-id :name])]
-      (is (empty? (:nodes (admin/nodes-stats conn :nodes "foo"))))
-      (is (= 1 (count (:nodes (admin/nodes-stats conn :nodes (name node-id))))))
-      (is (= 1 (count (:nodes (admin/nodes-stats conn :nodes (vector (name node-id)))))))
-      (is (= 1 (count (:nodes (admin/nodes-stats conn :nodes node-name)))))))
+      (is (empty? (:nodes (admin/nodes-stats conn {:nodes "foo"}))))
+      (is (= 1 (count (:nodes (admin/nodes-stats conn {:nodes (name node-id)})))))
+      (is (= 1 (count (:nodes (admin/nodes-stats conn {:nodes (vector (name node-id))})))))
+      (is (= 1 (count (:nodes (admin/nodes-stats conn {:nodes node-name})))))))
   (testing "parameters"
-    (is (not (= (admin/nodes-stats conn {:indices true}) (admin/nodes-stats conn :indices false))))
-    (is (not (= (admin/nodes-stats conn {:network true}) (admin/nodes-stats conn :network false)))))))
+    (is (not (= (admin/nodes-stats conn {:indices true}) (admin/nodes-stats conn {:indices false}))))
+    (is (not (= (admin/nodes-stats conn {:network true}) (admin/nodes-stats conn {:network false})))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/bool_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/bool_query_test.clj
@@ -21,9 +21,9 @@
   (deftest ^{:rest true :query true} test-basic-bool-query
     (let [index-name   "people"
           mapping-type "person"
-          response     (doc/search conn index-name mapping-type :query (q/bool :must   {:term {:planet "earth"}}
-                                                                               :should {:range {:age {:from 20 :to 30}}}
-                                                                               :minimum_number_should_match 1))]
+          response     (doc/search conn index-name mapping-type {:query (q/bool {:must   {:term {:planet "earth"}}
+                                                                                 :should {:range {:age {:from 20 :to 30}}}
+                                                                                 :minimum_number_should_match 1})})]
       (is (any-hits? response))
       (is (= (sort (ids-from response)) (sort ["1" "2" "4"])))
       (is (= 3 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/filtered_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/filtered_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:rest true :query true} test-basic-filtered-query
     (let [index-name   "people"
           mapping-type "person"
-          response     (doc/search conn index-name mapping-type :query (q/filtered :query  (q/term :planet "earth")
-                                                                                   :filter {:range {:age {:from 20 :to 30}}}))]
+          response     (doc/search conn index-name mapping-type {:query (q/filtered {:query  (q/term :planet "earth")
+                                                                                     :filter {:range {:age {:from 20 :to 30}}}})})]
       (is (any-hits? response))
       (is (= 3 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/fuzzy_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/fuzzy_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:rest true :query true} test-basic-fuzzy-query-with-string-fields
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/fuzzy :title "Nueva"))
+          response     (doc/search conn index-name mapping-type {:query (q/fuzzy {:title "Nueva"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))
@@ -32,7 +32,7 @@
   (deftest ^{:rest true :query true} test-basic-fuzzy-query-with-numeric-fields
     (let [index-name   "articles"
           mapping-type "article"
-          response (doc/search conn index-name mapping-type :query (q/fuzzy :number-of-edits {:value 13000 :fuzziness 3}))
+          response (doc/search conn index-name mapping-type {:query (q/fuzzy {:number-of-edits {:value 13000 :fuzziness 3}})})
           hits     (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))
@@ -41,7 +41,7 @@
   (deftest ^{:rest true :query true} test-basic-fuzzy-query-with-date-fields
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/fuzzy "latest-edit.date" {:value "2012-03-25T12:00:00" :fuzziness "1d"}))
+          response     (doc/search conn index-name mapping-type {:query (q/fuzzy {"latest-edit.date" {:value "2012-03-25T12:00:00" :fuzziness "1d"}})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))

--- a/test/clojurewerkz/elastisch/rest_api/queries/ids_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/ids_query_test.clj
@@ -20,7 +20,7 @@
 
 (let [conn (rest/connect)]
   (deftest ^{:rest true :query true} test-basic-ids-query
-  (let [response (doc/search conn "tweets" "tweet" :query (q/ids "tweet" ["1" "2" "8ska88"]))]
+  (let [response (doc/search conn "tweets" "tweet" {:query (q/ids "tweet" ["1" "2" "8ska88"])})]
     (is (any-hits? response))
     (is (= 2 (total-hits response)))
     (is (= #{"1" "2"} (set (map :_id (hits-from response))))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/match_all_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/match_all_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:rest true :query true} test-basic-match-all-query
   (let [index-name   "articles"
         mapping-type "article"
-        response     (doc/search conn index-name mapping-type :query (q/match-all))
+        response     (doc/search conn index-name mapping-type {:query (q/match-all)})
         hits         (hits-from response)]
     (is (any-hits? response))
     (is (= 4 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/mlt_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/mlt_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:query true :rest true} test-more-like-this-query
     (let [index-name   "articles"
           mapping-type "article"
-          response (doc/search conn index-name mapping-type :query (q/mlt :like_text "technology, opensource, search, full-text search, distributed, software, lucene"
-                                                                          :fields ["tags"] :min_term_freq 1 :min_doc_freq 1))]
+          response (doc/search conn index-name mapping-type {:query (q/mlt {:like_text "technology, opensource, search, full-text search, distributed, software, lucene"
+                                                                            :fields ["tags"] :min_term_freq 1 :min_doc_freq 1})})]
       (is (= 2 (total-hits response)))
       (is (= #{"1" "2"} (ids-from response))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/prefix_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/prefix_query_test.clj
@@ -22,7 +22,7 @@
   (deftest ^{:rest true :query true} test-basic-prefix-query
     (let [index-name   "people"
           mapping-type "person"
-          response     (doc/search conn index-name mapping-type :query (q/prefix :username "esj"))
+          response     (doc/search conn index-name mapping-type {:query (q/prefix {:username "esj"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 2 (total-hits response)))
@@ -31,7 +31,7 @@
   (deftest ^{:rest true :query true} test-full-word-prefix-query-over-a-text-field-analyzed-with-the-standard-analyzer
     (let [index-name   "tweets"
           mapping-type "tweet"
-          response (doc/search conn index-name mapping-type :query (q/prefix :text "why"))
+          response (doc/search conn index-name mapping-type {:query (q/prefix {:text "why"})})
           hits     (hits-from response)]
       (is (= 1 (total-hits response)))
       (is (= "4" (-> hits first :_id)))))
@@ -39,7 +39,7 @@
   (deftest ^{:rest true :query true} test-partial-prefix-query-over-a-text-field
     (let [index-name   "tweets"
           mapping-type "tweet"
-          response (doc/search conn index-name mapping-type :query (q/prefix :text "congr"))
+          response (doc/search conn index-name mapping-type {:query (q/prefix {:text "congr"})})
           hits     (hits-from response)]
       (is (= 1 (total-hits response)))
       (is (= "3" (-> hits first :_id)))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/query_string_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/query_string_query_test.clj
@@ -23,25 +23,25 @@
   (deftest ^{:rest true :query true} test-query-string-query
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/query-string :query "Austin" :default_field "title"))]
+          response     (doc/search conn index-name mapping-type {:query (q/query-string {:query "Austin" :default_field "title"})})]
       (is (= 1 (total-hits response)))
       (is (= #{"4"} (ids-from response)))))
 
   (deftest ^{:rest true :query true} test-query-string-query-across-all-mapping-types
     (let [index-name   "articles"
-          response     (doc/search-all-types conn index-name :query (q/query-string :query "Austin" :default_field "title"))]
+          response     (doc/search-all-types conn index-name {:query (q/query-string {:query "Austin" :default_field "title"})})]
       (is (= 1 (total-hits response)))
       (is (= #{"4"} (ids-from response)))))
 
   (deftest ^{:rest true :query true} test-query-string-query-across-all-indexes-and-mapping-types
-    (let [response     (doc/search-all-indexes-and-types conn :query (q/query-string :query "Austin" :default_field "title"))]
+    (let [response     (doc/search-all-indexes-and-types conn {:query (q/query-string {:query "Austin" :default_field "title"})})]
       (is (= 1 (total-hits response)))
       (is (= #{"4"} (ids-from response)))))
 
   (deftest ^{:rest true :query true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case1
     (let [index-name   "tweets"
           mapping-type "tweet"
-          response (doc/search conn index-name mapping-type :query (q/query-string :query "cloud+"))
+          response (doc/search conn index-name mapping-type {:query (q/query-string {:query "cloud+"})})
           hits     (hits-from response)]
       (is (= 1 (total-hits response)))
       (is (= "5" (-> hits first :_id)))))
@@ -49,6 +49,6 @@
   (deftest ^{:rest true :query true} test-query-string-query-over-a-text-field-analyzed-with-the-standard-analyzer-case2
     (let [index-name   "tweets"
           mapping-type "tweet"
-          response (doc/search conn index-name mapping-type :query (q/query-string :query "cloud AND (NOT adoption)"))
+          response (doc/search conn index-name mapping-type {:query (q/query-string {:query "cloud AND (NOT adoption)"})})
           hits     (hits-from response)]
       (is (= 0 (total-hits response))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/range_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/range_query_test.clj
@@ -23,7 +23,7 @@
   (deftest ^{:rest true :query true} test-range-query-over-numerical-field
   (let [index-name   "people"
         mapping-type "person"
-        response     (doc/search conn index-name mapping-type :query (q/range :age :from 27 :to 29))
+        response     (doc/search conn index-name mapping-type {:query (q/range :age {:from 27 :to 29})})
         hits         (hits-from response)]
     (is (any-hits? response))
     (is (= 2 (total-hits response)))
@@ -33,19 +33,19 @@
 (let [index-name   "tweets"
       mapping-type "tweet"]
   (deftest ^{:rest true :query true} test-range-query-over-string-field
-    (let [response (doc/search conn index-name mapping-type :query (q/range :username :from "c" :to "j"))
+    (let [response (doc/search conn index-name mapping-type {:query (q/range :username {:from "c" :to "j"})})
           ids      (ids-from response)]
       (is (= 2 (total-hits response)))
       (is (= #{"1" "2"} ids))))
 
   (deftest ^{:rest true :query true} test-range-query-over-date-time-field-with-from
-    (let [response (doc/search conn index-name mapping-type :query (q/range :timestamp :from "20120801T160000+0100"))
+    (let [response (doc/search conn index-name mapping-type {:query (q/range :timestamp {:from "20120801T160000+0100"})})
           ids      (ids-from response)]
       (is (= 2 (total-hits response)))
       (is (= #{"1" "2"} ids))))
 
   (deftest ^{:rest true :query true} test-range-query-over-date-time-field-with-from-and-to
-     (let [response (doc/search conn index-name mapping-type :query (q/range :timestamp :from "20120801T160000+0100" :to "20120801T180000+0100"))
+     (let [response (doc/search conn index-name mapping-type {:query (q/range :timestamp {:from "20120801T160000+0100" :to "20120801T180000+0100"})})
            ids      (ids-from response)]
        (is (= 1 (total-hits response)))
        (is (= #{"2"} ids))))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/span_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/span_query_test.clj
@@ -25,7 +25,7 @@
     ;; [[clojurewerkz.elastisch.fixtures/person-jack]]) requires searching for
     ;; the word “eat” —not “eating”— because the `biography` field is indexed
     ;; with the `snowball` analyzer.
-    (let [response (doc/search conn "people" "person" :query (q/span-first :match {:span_term {:biography "eat"}} :end 5))
+    (let [response (doc/search conn "people" "person" {:query (q/span-first {:match {:span_term {:biography "eat"}} :end 5})})
           hits     (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))
@@ -35,8 +35,8 @@
     ;; Similarly to the previous test, we search for “document” instead of
     ;; “documents” (which is what [[clojurewerkz.elastisch.fixtures/article-on-elasticsearch]])
     ;; *actually* contains).
-    (let [response (doc/search conn "articles" "article" :query (q/span-near :clauses [{:span_term {:summary "search"}}
-                                                                                       {:span_term {:summary "document"}}] :slop 5 :in_order true))
+    (let [response (doc/search conn "articles" "article" {:query (q/span-near {:clauses [{:span_term {:summary "search"}}
+                                                                                         {:span_term {:summary "document"}}] :slop 5 :in_order true})})
           hits (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))

--- a/test/clojurewerkz/elastisch/rest_api/queries/term_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/term_query_test.clj
@@ -21,30 +21,30 @@
 
 (let [conn (rest/connect)]
   (deftest ^{:rest true :query true} test-basic-term-query-with-person-mapping
-    (let [result (doc/search conn "people" "person" :query (q/term :biography "avoid"))]
+    (let [result (doc/search conn "people" "person" {:query (q/term :biography "avoid")})]
       (is (any-hits? result))
       (is (= fx/person-jack (-> result hits-from first :_source)))))
 
 
   (deftest ^{:rest true :query true} test-term-query-with-person-mapping-and-a-limit
-    (let [result (doc/search conn "people" "person" :query (q/term :planet "earth") :size 2)]
+    (let [result (doc/search conn "people" "person" {:query (q/term :planet "earth") :size 2})]
       (is (any-hits? result))
       (is (= 2 (count (hits-from result))))
       ;; but total # of hits is reported w/o respect to the limit. MK.
       (is (= 4 (total-hits result)))))
 
   (deftest ^{:rest true :query true} test-basic-term-query-with-tweets-mapping
-    (let [result (doc/search conn "tweets" "tweet" :query (q/term :text "improved"))]
+    (let [result (doc/search conn "tweets" "tweet" {:query (q/term :text "improved")})]
       (is (any-hits? result))
       (is (= fx/tweet1 (-> result hits-from first :_source)))))
 
   (deftest ^{:rest true :query true} test-basic-terms-query-with-tweets-mapping
-    (let [result (doc/search conn "tweets" "tweet" :query (q/term :text ["supported" "improved"]))]
+    (let [result (doc/search conn "tweets" "tweet" {:query (q/term :text ["supported" "improved"])})]
       (is (any-hits? result))
       (is (= fx/tweet1 (-> result hits-from first :_source)))))
 
   (deftest ^{:rest true :query true} test-basic-term-query-over-non-analyzed-usernames
-    (are [username id] (= id (-> (doc/search conn "tweets" "tweet" :query (q/term :username username) :sort {:timestamp "asc"})
+    (are [username id] (= id (-> (doc/search conn "tweets" "tweet" {:query (q/term :username username) :sort {:timestamp "asc"}})
                                      hits-from
                                      first
                                      :_id))
@@ -54,7 +54,7 @@
          "DEVOPS_BORAT"   "5"))
 
   (deftest ^{:rest true :query true} test-basic-term-query-over-non-analyzed-embedded-fields
-    (are [state id] (= id (-> (doc/search conn "tweets" "tweet" :query (q/term "location.state" state) :sort {:timestamp "asc"})
+    (are [state id] (= id (-> (doc/search conn "tweets" "tweet" {:query (q/term "location.state" state) :sort {:timestamp "asc"}})
                                   hits-from
                                   first
                                   :_id))

--- a/test/clojurewerkz/elastisch/rest_api/queries/wildcard_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/wildcard_query_test.clj
@@ -20,7 +20,7 @@
 
 (let [conn (rest/connect)]
   (deftest ^{:rest true :query true} test-trailing-wildcard-query-with-nested-fields
-    (let [response     (doc/search conn "articles" "article" :query (q/wildcard "latest-edit.author" "Thorw*"))
+    (let [response     (doc/search conn "articles" "article" {:query (q/wildcard {"latest-edit.author" "Thorw*"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))
@@ -28,7 +28,7 @@
 
 
   (deftest ^{:rest true :query true} test-leading-wildcard-query-with-non-analyzd-field
-    (let [response     (doc/search conn "tweets" "tweet" :query (q/wildcard :username "*werkz"))
+    (let [response     (doc/search conn "tweets" "tweet" {:query (q/wildcard {:username "*werkz"})})
           hits         (hits-from response)]
       (is (any-hits? response))
       (is (= 1 (total-hits response)))

--- a/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_scroll_test.clj
@@ -21,7 +21,7 @@
 (let [conn (rest/connect)]
   (defn fetch-scroll-results
     [scroll-id results]
-    (let [scroll-response (doc/scroll conn scroll-id :scroll "1m")
+    (let [scroll-response (doc/scroll conn scroll-id {:scroll "1m"})
           hits            (hits-from scroll-response)]
       (if (seq hits)
         (recur (:_scroll_id scroll-response) (concat results hits))
@@ -31,13 +31,13 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :search_type "scan"
-                                   :scroll "1m"
-                                   :size 1)
+                                   {:query (q/match-all)
+                                    :search_type "scan"
+                                    :scroll "1m"
+                                    :size 1})
           initial-hits  (hits-from response)
           scroll-id     (:_scroll_id response)
-          scan-response (doc/scroll conn scroll-id :scroll "1m")
+          scan-response (doc/scroll conn scroll-id {:scroll "1m"})
           scan-hits     (hits-from scan-response)]
       (is (any-hits? response))
       (is (= 4 (total-hits response)))
@@ -52,13 +52,13 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :search_type "query_then_fetch"
-                                   :scroll "1m"
-                                   :size 2)
+                                   {:query (q/match-all)
+                                    :search_type "query_then_fetch"
+                                    :scroll "1m"
+                                    :size 2})
           initial-hits    (hits-from response)
           scroll-id       (:_scroll_id response)
-          scroll-response (doc/scroll conn scroll-id :scroll "1m")
+          scroll-response (doc/scroll conn scroll-id {:scroll "1m"})
           scroll-hits     (hits-from scroll-response)]
       (is (any-hits? response))
       (is (= 4 (total-hits response)))
@@ -70,10 +70,10 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type
-                                   :query (q/match-all)
-                                   :search_type "query_then_fetch"
-                                   :scroll "1m"
-                                   :size 1)
+                                   {:query (q/match-all)
+                                    :search_type "query_then_fetch"
+                                    :scroll "1m"
+                                    :size 1})
           initial-hits (hits-from response)
           scroll-id    (:_scroll_id response)
           all-hits     (fetch-scroll-results scroll-id initial-hits)]
@@ -86,10 +86,10 @@
           mapping-type "article"
           res-seq      (doc/scroll-seq conn
                                        (doc/search conn index-name mapping-type
-                                                   :query (q/match-all)
-                                                   :search_type "query_then_fetch"
-                                                   :scroll "1m"
-                                                   :size 2))]
+                                                   {:query (q/match-all)
+                                                    :search_type "query_then_fetch"
+                                                    :scroll "1m"
+                                                    :size 2}))]
       (is (not (realized? res-seq)))
       (is (= 4 (count res-seq)))
       (is (= 4 (count (distinct res-seq))))
@@ -100,10 +100,10 @@
           mapping-type "article"
           res-seq      (doc/scroll-seq conn
                                        (doc/search conn index-name mapping-type
-                                                   :query (q/match-all)
-                                                   :search_type "scan"
-                                                   :scroll "1m"
-                                                   :size 2)
+                                                   {:query (q/match-all)
+                                                    :search_type "scan"
+                                                    :scroll "1m"
+                                                    :size 2})
                                        {:search_type "scan"})]
       (is (not (realized? res-seq)))
       (is (= 4 (count res-seq)))
@@ -115,9 +115,9 @@
           mapping-type "article"
           res-seq      (doc/scroll-seq conn
                                        (doc/search conn index-name mapping-type
-                                                   :query (q/term :title "Emptiness")
-                                                   :search_type "query_then_fetch"
-                                                   :scroll "1m"
-                                                   :size 2))]
+                                                   {:query (q/term :title "Emptiness")
+                                                    :search_type "query_then_fetch"
+                                                    :scroll "1m"
+                                                    :size 2}))]
       (is (= 0 (count res-seq)))
       (is (coll? res-seq)))))

--- a/test/clojurewerkz/elastisch/rest_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_test.clj
@@ -34,28 +34,28 @@
                                                     :planet     "Earth"
                                                     :age 42}))
         (idx/refresh conn index-name)
-        (let [result (doc/search conn index-name mapping-type :query (q/term :biography "say"))]
+        (let [result (doc/search conn index-name mapping-type {:query (q/term :biography "say")})]
           (is (= 1 (total-hits result)))))))
 
   (deftest ^{:rest true} test-search-query-with-basic-filtering
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query  (q/match-all)
-                                              :filter {:term {:username "esmary"}}))]
+                                              {:query  (q/match-all)
+                                               :filter {:term {:username "esmary"}}}))]
       (is (= 1 (count hits)))
       (is (= "Lindey" (-> hits first :_source :last-name)))))
 
   (deftest ^{:query true} test-query-validation
     (let [index-name   "articles"
-          response     (doc/validate-query conn index-name (q/term "latest-edit.author" "Thorwald") :explain true)]
+          response     (doc/validate-query conn index-name (q/term "latest-edit.author" "Thorwald") {:explain true})]
       (is (valid? response))))
 
   (deftest ^{:rest true} test-basic-sorting-over-string-field-with-desc-order
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/match-all)
-                                   :sort {"title" "desc"})
+          response     (doc/search conn index-name mapping-type {:query (q/match-all)
+                                   :sort {"title" "desc"}})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits first :_source :title)))
@@ -64,8 +64,8 @@
   (deftest ^{:rest true} test-basic-sorting-over-string-field-with-asc-order
     (let [index-name   "articles"
           mapping-type "article"
-          response     (doc/search conn index-name mapping-type :query (q/match-all)
-                                   :sort {"title" "asc"})
+          response     (doc/search conn index-name mapping-type {:query (q/match-all)
+                                   :sort {"title" "asc"}})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits last :_source :title)))
@@ -75,9 +75,9 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    {"first-name" "asc"}
-                                              :_source ["first-name" "age"]))]
+                                              {:query   (q/match-all)
+                                               :sort    {"first-name" "asc"}
+                                               :_source ["first-name" "age"]}))]
       (is (= 4 (count hits)))
       (is (= {:first-name "Tony" :age 29} (-> hits last :_source)))))
 
@@ -85,11 +85,11 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    {"first-name" "asc"}
-                                              :_source {"exclude" ["title" "country"
-                                                                   "planet" "biography"
-                                                                   "last-name" "username"]}))]
+                                              {:query   (q/match-all)
+                                               :sort    {"first-name" "asc"}
+                                               :_source {"exclude" ["title" "country"
+                                                                    "planet" "biography"
+                                                                    "last-name" "username"]}}))]
       (is (= 4 (count hits)))
       (is (= #{:first-name :age :signed_up_at} (set (keys (-> hits last :_source)))))))
 
@@ -97,10 +97,10 @@
     (let [index-name   "people"
           mapping-type "person"
           hits         (hits-from (doc/search conn index-name mapping-type
-                                              :query   (q/match-all)
-                                              :sort    (q/sort "surname"
-                                                               {:order "asc"
-                                                                :ignore-unmapped true})))]
+                                              {:query   (q/match-all)
+                                               :sort    (q/sort "surname"
+                                                                {:order "asc"
+                                                                 :ignore-unmapped true})}))]
       (is (= 4 (count hits)))))
 
   (deftest ^{:rest true} test-ignore-unavailable
@@ -109,9 +109,9 @@
           mapping-type "person"]
       (is (= 4 (count (hits-from (doc/search conn [index-name missing-index-name] 
                                              mapping-type
-                                             :query   (q/match-all)
-                                             :ignore_unavailable true)))))
+                                             {:query   (q/match-all)
+                                              :ignore_unavailable true})))))
       (is (thrown? Exception 
                    (doc/search conn [index-name missing-index-name]
                                mapping-type
-                               :query   (q/match-all)))))))
+                               {:query   (q/match-all)}))))))

--- a/test/clojurewerkz/elastisch/rest_api/search_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/search_test.clj
@@ -55,7 +55,7 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type {:query (q/match-all)
-                                   :sort {"title" "desc"}})
+                                                                 :sort {"title" "desc"}})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits first :_source :title)))
@@ -65,7 +65,7 @@
     (let [index-name   "articles"
           mapping-type "article"
           response     (doc/search conn index-name mapping-type {:query (q/match-all)
-                                   :sort {"title" "asc"}})
+                                                                 :sort {"title" "asc"}})
           hits         (hits-from response)]
       (is (= 4 (total-hits response)))
       (is (= "Nueva York" (-> hits last :_source :title)))

--- a/test/clojurewerkz/elastisch/rest_api/update_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/update_test.clj
@@ -25,25 +25,25 @@
           mapping-type "person"
           id           "3"
           new-bio      "Such a brilliant person"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
       (doc/put conn index-name mapping-type "1" fx/person-jack)
       (doc/put conn index-name mapping-type "2" fx/person-mary)
       (doc/put conn index-name mapping-type "3" fx/person-joe)
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name mapping-type :query (q/term :biography "nice"))))
-      (is (no-hits? (doc/search conn index-name mapping-type :query (q/term :biography "brilliant"))))
+      (is (any-hits? (doc/search conn index-name mapping-type {:query (q/term :biography "nice")})))
+      (is (no-hits? (doc/search conn index-name mapping-type {:query (q/term :biography "brilliant")})))
       (doc/replace conn index-name mapping-type id (assoc fx/person-joe :biography new-bio))
       (idx/refresh conn index-name)
-      (is (any-hits? (doc/search conn index-name mapping-type :query (q/term :biography "brilliant"))))
-      (is (no-hits? (doc/search conn index-name mapping-type :query (q/term :biography "nice"))))))
+      (is (any-hits? (doc/search conn index-name mapping-type {:query (q/term :biography "brilliant")})))
+      (is (no-hits? (doc/search conn index-name mapping-type {:query (q/term :biography "nice")})))))
 
   (deftest ^{:rest true} test-versioning
     (let [index-name "people"
           index-type "person"
           id         "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
-      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") :id id)
+      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") {:id id})
       (idx/refresh conn index-name)
 
       (let [original-document (doc/get conn index-name index-type id)
@@ -65,9 +65,9 @@
           index-type "person"
           id         "1"
           person (assoc fx/person-jack :biography "brilliant1")]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
-      (doc/create conn index-name index-type person :id id)
+      (doc/create conn index-name index-type person {:id id})
       (idx/refresh conn index-name)
 
       (let [original-document (doc/get conn index-name index-type id)]
@@ -85,7 +85,7 @@
           index-type "person"
           id         "1"
           person (assoc fx/person-jack :biography "brilliant1" :country "India")]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
       (idx/refresh conn index-name)
       ;; http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html#upserts
@@ -101,9 +101,9 @@
     (let [index-name "people"
           index-type "person"
           id         "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
-      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") :id id)
+      (doc/create conn index-name index-type (assoc fx/person-jack :biography "brilliant1") {:id id})
       (idx/refresh conn index-name)
 
       (let [original-document (doc/get conn index-name index-type id)]
@@ -121,9 +121,9 @@
     (let [index-name "people"
           index-type "person"
           id "1"]
-      (idx/create conn index-name :mappings fx/people-mapping)
+      (idx/create conn index-name {:mappings fx/people-mapping})
 
-      (doc/create conn index-name index-type fx/person-jack :id id)
+      (doc/create conn index-name index-type fx/person-jack {:id id})
 
       (idx/refresh conn index-name)
 
@@ -149,7 +149,7 @@
       (testing "update with groovy script no params"
         (let [orig (doc/get conn index-name index-type id)]
           (doc/update-with-script conn index-name index-type id
-                                  "ctx._source.age = ctx._source.age += 1" {} :lang "groovy")
+                                  "ctx._source.age = ctx._source.age += 1" {} {:lang "groovy"})
           (idx/refresh conn index-name)
           (is (= (-> orig :_source :age inc)
                  (-> (doc/get conn index-name index-type id) :_source  :age))))))))


### PR DESCRIPTION
(resolves #215)

@michaelklishin _assuming this all looks good to you_, feel free to just +1 in a comment and let me do a fast-forward merge into `master`. Or, if you’d prefer, skip the +1 and explicitly merge the PR yourself—it’s totally up to you.

A couple thoughts:

* With a _few_ of the functions, the “look” of the final options-map seems a tad funky, at least to me. For example:

  ```clojure
  (doc/create conn "people" "person" {:first-name "John" :last-name "Appleseed" :age 28} {:id "1825c5432775b8d1a477acfae57e91ac8c767aed"})

(doc/update-with-script conn index-name index-type id
                            "ctx._source.age = ctx._source.age += 1" {} {:lang "groovy"})
  ```

  I mean, it works, but I wonder if an API more like the `bulk`-functions would be preferable. However, I think we could figure that out in a separate Issue once this PR is merged.

* I’m conflicted about which to prefer as a convention throughout the codebase:

  ```clojure
  (defn ^Node build-local-node
    ([settings] (build-local-node settings nil))
    ([settings {:keys [client], :or {client true}}]
     (let [is (cnv/->settings settings)
           nb (.. NodeBuilder nodeBuilder
                  (settings is)
                  (client client))]
       (.build ^NodeBuilder nb))))
  ```

  ```clojure
  (defn ^Node build-local-node
    ([settings]
     (build-local-node settings nil))
    ([settings {:keys [client], :or {client true}}]
     (let [is (cnv/->settings settings)
           nb (.. NodeBuilder nodeBuilder
                  (settings is)
                  (client client))]
       (.build ^NodeBuilder nb))))
  ```

  The current form of the PR uses the first style, but let me know if you prefer the latter.