### PR TITLE
Improve scrolls: fix scroll ttl bug and implement scroll-clear

### DIFF
--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -277,10 +277,12 @@
   ([^Connection conn prev-resp]
    (scroll-seq conn prev-resp nil)))
 
-(defn scroll-clear
+(defn clear-scroll
   "Clear the scroll."
   [^Connection conn scroll-id]
-  (rest/delete conn (rest/delete-by-query-url conn) {:scroll_id scroll-id}))
+  (rest/delete conn
+               (rest-api/url-with-path conn "_search" "scroll")
+               {:body {:scroll_id [scroll-id]}}))
 
 (defn replace
   "Replaces document with given id with a new one"

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -264,9 +264,10 @@
 
 (defn scroll-seq
   "Returns a lazy sequence of all documents for a given scroll query"
-  ([^Connection conn prev-resp {:keys [search_type] scroll-ttl :scroll
-                                :or {scroll "1m"} :as opts}]
+  ([^Connection conn prev-resp {scroll-ttl :scroll
+                                :keys [search_type] :as opts}]
    (let [hits (hits-from prev-resp)
+         scroll-ttl (or scroll-ttl "1m")
          scroll-id (:_scroll_id prev-resp)]
      (if (or (seq hits) (= search_type "scan"))
        (->> (scroll conn scroll-id {:scroll scroll-ttl})
@@ -281,7 +282,7 @@
   "Clear the scroll."
   [^Connection conn scroll-id]
   (rest/delete conn
-               (rest-api/url-with-path conn "_search" "scroll")
+               (rest/url-with-path conn "_search" "scroll")
                {:body {:scroll_id [scroll-id]}}))
 
 (defn replace

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -277,6 +277,11 @@
   ([^Connection conn prev-resp]
    (scroll-seq conn prev-resp nil)))
 
+(defn scroll-clear
+  "Clear the scroll."
+  [^Connection conn scroll-id]
+  (rest/delete conn (rest/delete-by-query-url conn) {:scroll_id scroll-id}))
+
 (defn replace
   "Replaces document with given id with a new one"
   [^Connection conn index mapping-type id document]

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -265,13 +265,13 @@
 (defn scroll-seq
   "Returns a lazy sequence of all documents for a given scroll query"
   ([^Connection conn prev-resp {scroll-ttl :scroll
-                                :keys [search_type] :as opts}]
+                                :or {scroll-ttl "1m"}
+                                :keys [search_type]}]
    (let [hits (hits-from prev-resp)
-         scroll-ttl (or scroll-ttl "1m")
          scroll-id (:_scroll_id prev-resp)]
      (if (or (seq hits) (= search_type "scan"))
        (->> (scroll conn scroll-id {:scroll scroll-ttl})
-            (#(scroll-seq conn % opts))
+            (#(scroll-seq conn % {:scroll scroll-ttl}))
             (lazy-seq)
             (concat hits))
        hits)))


### PR DESCRIPTION
In the current version, the :scroll argument isn't preserved after the 2nd call, only the first one will have the correct ttl. This bug is fixed in the 1st commit.

Meanwhile, because big ttl can have a big performance on indexing, the deletion of scroll is implemented in this PR as well to reduce this problem.