### PR TITLE
Add support for type query

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,15 @@
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
+### Add support for type query
+Added helper function for a [type query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html).
+
+Contributed by @nivekuil.
+
 ### ElasticSeach 2.3.x Compatibility
 
 This involves removing some features as [Elasticsearch 2.0 has breaking public API changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-2.0.html).
 
 Contributed by Timo Sulg and Josh Tilles.
-
 
 ### Make it Possible to Override *any* clj-http Option
 

--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -67,6 +67,14 @@
   [opts]
   {:boosting opts})
 
+
+(defn type
+  "Type Query
+
+  For more information, please refer to http://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-type-query.html"
+  [type]
+  {:type {:value type}})
+
 (defn ids
   "IDs Query
 

--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -67,14 +67,6 @@
   [opts]
   {:boosting opts})
 
-
-(defn type
-  "Type Query
-
-  For more information, please refer to http://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-type-query.html"
-  [type]
-  {:type {:value type}})
-
 (defn ids
   "IDs Query
 
@@ -222,6 +214,13 @@
    For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html"
   [opts]
   {:nested opts})
+
+(defn type
+  "Type Query
+
+  For more information, please refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-type-query.html"
+  [type]
+  {:type {:value type}})
 
 (defn sort
   "Sort query results."

--- a/test/clojurewerkz/elastisch/native_api/queries/type_query_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/queries/type_query_test.clj
@@ -1,0 +1,26 @@
+;; Copyright (c) 2011-2015 Michael S. Klishin, Alex Petrov, and the ClojureWerkz Team
+;;
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns clojurewerkz.elastisch.native-api.queries.type-query-test
+  (:require [clojurewerkz.elastisch.native.document :as doc]
+            [clojurewerkz.elastisch.query           :as q]
+            [clojurewerkz.elastisch.fixtures        :as fx]
+            [clojurewerkz.elastisch.test.helpers    :as th]
+            [clojurewerkz.elastisch.native.response :refer :all]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each fx/reset-indexes fx/prepopulate-tweets-index)
+
+(let [conn (th/connect-native-client)]
+  (deftest ^{:query true :native true} test-basic-type-query
+    (let [response (doc/search conn "tweets" "tweet"
+                               {:query (q/type "tweet")})]
+      (is (any-hits? response))
+      (is (= 5 (total-hits response)))
+      (is (= #{"tweet"} (set (map :_type (hits-from response))))))))

--- a/test/clojurewerkz/elastisch/query_test.clj
+++ b/test/clojurewerkz/elastisch/query_test.clj
@@ -67,6 +67,10 @@
          positive-boost (:positive_boost boosting)
          negative-boost (:negative_boost boosting))))
 
+(deftest type-query-test
+  (is (=  {:type {:value "my_type"}}
+          (query/type "my_type"))))
+
 (deftest ids-query-test
   (is (=  {:ids {:type "my_type" :values  ["1" "4" "100"]}}
           (query/ids "my_type" ["1" "4" "100"]))))

--- a/test/clojurewerkz/elastisch/rest_api/queries/type_query_test.clj
+++ b/test/clojurewerkz/elastisch/rest_api/queries/type_query_test.clj
@@ -1,0 +1,26 @@
+;; Copyright (c) 2011-2015 Michael S. Klishin, Alex Petrov, and the ClojureWerkz Team
+;;
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns clojurewerkz.elastisch.rest-api.queries.type-query-test
+  (:require [clojurewerkz.elastisch.rest.document :as doc]
+            [clojurewerkz.elastisch.rest          :as rest]
+            [clojurewerkz.elastisch.query         :as q]
+            [clojurewerkz.elastisch.fixtures      :as fx]
+            [clojurewerkz.elastisch.rest.response :refer :all]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each fx/reset-indexes fx/prepopulate-tweets-index)
+
+(let [conn (rest/connect)]
+  (deftest ^{:query true :rest true} test-basic-type-query
+    (let [response (doc/search conn "tweets" "tweet"
+                               {:query (q/type "tweet")})]
+      (is (any-hits? response))
+      (is (= 5 (total-hits response)))
+      (is (= #{"tweet"} (set (map :_type (hits-from response))))))))


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html

On an unrelated note, elasticsearch.org now redirects to elastic.co. I could amend the docstrings to use the new URL if desired.