### PR TITLE
Add support for _version and _version_type in bulk

### DIFF
--- a/src/clojurewerkz/elastisch/common/bulk.clj
+++ b/src/clojurewerkz/elastisch/common/bulk.clj
@@ -21,7 +21,9 @@
                                        :_script_params
                                        :_scripted_upsert
                                        :_timestamp
-                                       :_ttl])
+                                       :_ttl
+                                       :_version
+                                       :_version_type])
 
 (defn index-operation
   [doc]


### PR DESCRIPTION
Bulk operations support versioning parameters `_version` and `_version_type`, but these were ignored by Elastisch. This commit whitelists them as special parameters.