### PR TITLE
->search-request: Honor boolean _source param

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -544,7 +544,7 @@
   [^SearchSourceBuilder sb _source]
   (cond
    (nil? _source)        sb
-   (false? _source)      (.fetchSource sb false)
+   (boolean? _source)    (.fetchSource sb _source)
    (map? _source)        (let [m  (wlk/stringify-keys _source)
                                in (->string-array (m "include" []))
                                ex (->string-array (m "exclude" []))]


### PR DESCRIPTION
Fetching _source is the default for most searches, but if fields are
specified the _source is not returned by default. This commit ensures
the _source can be explicitly fetched when required.