### PR TITLE
added sort attribute to search results

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+### Added Sort Attribute to native search results
+Added the key :sort to each hit from the search results in order to remain
+close to feature parity
+
+Contributed by @KeeganMyers
+
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
 ### ElasticSeach 2.3.x Compatibility

--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -811,6 +811,7 @@
                                        :_type     (.getType sh)
                                        :_id       (.getId sh)
                                        :_score    (.getScore sh)
+                                       :sort      (vec (.getSortValues sh))
                                        :_version  (.getVersion sh)})
         result-with-source (if source
                              (assoc result :_source (convert-source-result source))


### PR DESCRIPTION
I noticed while working on GeoDistance queries with the native client that the sort attribute was missing from results. According to the official documentation a user should be able to return relative distances for a GeoDistance query using the sort attribute

https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-by-distance.html.

running a sample query via the native client did not return sort

```
(esd/search conn "loc-test" "locType"
{:query {:geo_distance
          {:distance "100mi"
           :location {:lat 38.8949648
                      :lon -77.02901450000002}}}
 :sort
(doto (GeoDistanceSortBuilder. "location")
  (.order (SortOrder/DESC))
  (.point 38.8949648 -77.02901450000002)
  (.unit (DistanceUnit/MILES)))
})

```

So I added the attribute to search results and named the key :sort rather than :_sort to keep the result similar to the rest client.
