### PR TITLE
handle native bulk create

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,12 @@
 ## Changes between Elastisch 2.2.2 and 2.2.3 (unreleased)
 
-No changes yet.
+### add support for native bulk create
 
+2 possible methods to perform create operations using native bulk
+* set the `_create` option to true in bulk index operations
+* use bulk-create
+
+Contributed by Mathieu Viel (@vielmath)
 
 ## Changes between Elastisch 2.2.1 and 2.2.2 (July 13th, 2016)
 

--- a/src/clojurewerkz/elastisch/common/bulk.clj
+++ b/src/clojurewerkz/elastisch/common/bulk.clj
@@ -12,6 +12,7 @@
 
 (def ^:private special-operation-keys [:_doc_as_upsert
                                        :_index
+                                       :_create
                                        :_type
                                        :_id
                                        :_retry_on_conflict

--- a/test/clojurewerkz/elastisch/native_api/bulk_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/bulk_test.clj
@@ -37,6 +37,26 @@
       (is (= 2 (count (:items (bulk conn bulk-operations {:refresh true})))))
       (is (= 2 (:count (doc/count conn index-name index-type))))))
 
+  (deftest ^{:native true :indexing true} test-bulk-indexing-create-flag
+    (let [person fx/person-jack
+          for-index (assoc person :_type index-type :_index index-name)
+          bulk-operations (bulk-index [(assoc for-index :_create true :_id "foo")
+                                       (assoc for-index :_create true :_id "foo")
+                                       (assoc for-index :_id "foo")])
+          bulk-res (bulk conn bulk-operations {:refresh true})]
+      (is (= 3 (count (:items bulk-res))))
+      (is (= 1 (:count (doc/count conn index-name index-type))))
+      (is (= '(1 -1 2) (map :version (:items bulk-res))))))
+
+  (deftest ^{:native true :indexing true} test-bulk-create
+    (let [person fx/person-jack
+          for-index (assoc person :_type index-type :_index index-name :_id "foo")
+          bulk-operations (bulk-create (repeat 2 for-index))
+          bulk-res (bulk conn bulk-operations {:refresh true})]
+      (is (= 2 (count (:items bulk-res))))
+      (is (= 1 (:count (doc/count conn index-name index-type))))
+      (is (= '(1 -1) (map :version (:items bulk-res))))))
+
   (deftest ^{:native true :indexing true} test-bulk-with-index
     (let [document fx/person-jack
           for-index (assoc document :_type index-type)


### PR DESCRIPTION
Hi there !

Bulk create works fine with the http client but is missing native implementation.
I've added `_create` in `common bulk special-operation-keys` and handled this option in `->index-request`.
I've also added the create request-type in `->action-requests` forcing the create option to true.

native `bulk-create` is now working as expected. 
It is also possible to set the `_create` option for each index action in a bulk index.