### PR TITLE
Fix some tests

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -1086,9 +1086,9 @@
 
 (defn ^DeleteIndexRequest ->delete-index-request
   ([]
-     (DeleteIndexRequest. (->string-array [])))
+   (DeleteIndexRequest. "_all"))
   ([index-name]
-     (DeleteIndexRequest. (->string-array index-name))))
+   (DeleteIndexRequest. (->string-array index-name))))
 
 (defn ^UpdateSettingsRequest ->update-settings-request
   [index-name settings]
@@ -1298,7 +1298,7 @@
 
 (defn ^IPersistentMap indices-stats-response->map
   "transforms a response of indices stats to the Clojure hash-map
-  
+
   note: parsing from JSON string presents index-names as Clojure keywords,
   which mean it may fail if you use characters not allowed as keyword.
   JSON version is used only for testing purpose or fallback when native version

--- a/src/clojurewerkz/elastisch/native/index.clj
+++ b/src/clojurewerkz/elastisch/native/index.clj
@@ -93,7 +93,7 @@
 (defn delete
   "Deletes an existing index"
   ([^Client conn]
-     (let [ft                       (es/admin-index-delete conn (cnv/->delete-index-request) "_all")
+     (let [ft                       (es/admin-index-delete conn (cnv/->delete-index-request))
            ^DeleteIndexResponse res (.actionGet ft)]
        {:ok (.isAcknowledged res) :acknowledged (.isAcknowledged res)}))
   ([^Client conn index-name]

--- a/test/clojurewerkz/elastisch/native_api/indices_test.clj
+++ b/test/clojurewerkz/elastisch/native_api/indices_test.clj
@@ -93,6 +93,7 @@
   (deftest ^{:indexing true :native true} test-index-stats-for-all-indexes
     (idx/create conn "group1")
     (idx/create conn "group2")
+    (Thread/sleep 1000)
     (let [res (idx/stats conn {:docs true :store true :indexing true})]
       (is (contains? res :_all))
       (is (contains? res :indices))


### PR DESCRIPTION
https://github.com/clojurewerkz/elastisch/pull/249 caused an arrity exception.

I also added a sleep in test-index-stats-for-all-indexes. It was failing because (for me) the stats call was made before the group2 index was successfully created.