### PR TITLE
Use PUT for create (POST doesn't work)

### DIFF
--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -68,12 +68,13 @@
 
 (defn put
   [^Connection conn ^String uri {:keys [body] :as options}]
-  (parse-safely
-    (:body (http/put uri (merge {:throw-exceptions throw-exceptions}
-                                (.http-opts conn)
-                                options
-                                {:accept :json
-                                 :body (json/encode body)})))))
+  (let [args (merge {:throw-exceptions throw-exceptions}
+                    (.http-opts conn)
+                    options
+                    {:accept :json
+                     :body (json/encode body)})]
+    (parse-safely   
+     (:body (http/put uri args)))))
 
 (defn get
   ([^Connection conn ^String uri]

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -255,12 +255,15 @@
   query given a scroll id"
   ([^Connection conn scroll-id] (scroll conn scroll-id nil))
   ([^Connection conn scroll-id opts]
-   (let [qk [:search_type :scroll :routing :preference]
+   (let [qk (cond-> [:search_type :routing :preference]
+              (not scroll-id) (conj :scroll))
          qp   (select-keys opts qk)
-         body scroll-id]
-     (rest/post-string conn (rest/scroll-url conn)
-                       {:body body
-                        :query-params qp}))))
+         body (if scroll-id
+                {:scroll (:scroll opts)
+                 :scroll_id scroll-id})]
+     (rest/post conn (rest/scroll-url conn)
+                {:body body
+                 :query-params qp}))))
 
 (defn scroll-seq
   "Returns a lazy sequence of all documents for a given scroll query"

--- a/src/clojurewerkz/elastisch/rest/index.clj
+++ b/src/clojurewerkz/elastisch/rest/index.clj
@@ -34,7 +34,7 @@
   (require '[clojurewerkz.elastisch.rest.index :as idx])
 
   (idx/create conn \"myapp_development\")
-  (idx/create conn \"myapp_development\" :settings {\"number_of_shards\" 1})
+  (idx/create conn \"myapp_development\" {:settings {\"number_of_shards\" 1}})
 
   (let [mapping-types {:person {:properties {:username   {:type \"string\" :store \"yes\"}
                                              :first-name {:type \"string\" :store \"yes\"}
@@ -43,7 +43,7 @@
                                              :title      {:type \"string\" :analyzer \"snowball\"}
                                              :planet     {:type \"string\"}
                                              :biography  {:type \"string\" :analyzer \"snowball\" :term_vector \"with_positions_offsets\"}}}}]
-    (idx/create conn \"myapp_development\" :mappings mapping-types))
+    (idx/create conn \"myapp_development\" {:mappings mapping-types}))
   ```
 
   Related Elasticsearch API Reference section:
@@ -51,11 +51,10 @@
   ([^Connection conn ^String index-name] (create conn index-name nil))
   ([^Connection conn ^String index-name opts]
    (let [{:keys [settings mappings]} opts]
-     (rest/post conn (rest/index-url conn
-                                     index-name)
-                {:body (if mappings
-                         {:settings settings :mappings mappings}
-                         {:settings settings})}))))
+     (rest/put conn (rest/index-url conn
+                                    index-name)
+               {:body (cond-> {:settings (or settings {})}
+                        mappings (assoc :mappings mappings))}))))
 
 (defn exists?
   "Used to check if the index (indices) exists or not.


### PR DESCRIPTION
I got an error when trying to create an index on my system (using ES 5.2.1).  Turns out that creating an index using POST is no longer supported, only PUT works.  I also fixed another error where it failed to create an error if there are no settings (settings are "null").  Passing in an empty settings map instead fixes it.