### PR TITLE
avoid a warning of type conflicting with clojure.core/type

### DIFF
--- a/src/clojurewerkz/elastisch/query.clj
+++ b/src/clojurewerkz/elastisch/query.clj
@@ -16,7 +16,7 @@
   "Convenience functions that build various query types.
 
    All functions return maps and are completely optional (but recommended)."
-  (:refer-clojure :exclude [range sort])
+  (:refer-clojure :exclude [range sort type])
   (:require [clojure.set :as set]
             [clojurewerkz.elastisch.escape    :as escape]))
 


### PR DESCRIPTION
avoid a warning of type conflicting with clojure.core/type 