### PR TITLE
Update to use Deps Versions for dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ and several others.
 ## Continuous Integration
 
 [![Continuous Integration status](https://secure.travis-ci.org/clojurewerkz/elastisch.png)](http://travis-ci.org/clojurewerkz/elastisch)
-[![Dependencies Status](http://jarkeeper.com/clojurewerkz/elastisch/status.svg)](http://jarkeeper.com/clojurewerkz/elastisch)
+[![Dependencies Status](https://versions.deps.co/clojurewerkz/elastisch/status.svg)](https://versions.deps.co/clojurewerkz/elastisch)
 
 ## Development
 


### PR DESCRIPTION
I noticed in the logs for Deps Versions that there was an error thrown trying to load https://versions.deps.co/clojurewerkz/elastisch a few weeks ago. I think I've resolved that error now, so I'm providing a PR. If this wasn't a maintainer checking this, and you don't want to switch, feel free to close this.