### PR TITLE
Elasticsearch 5 support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
  This is part of ongoing effort to support 5.x.
  POST calls now include content-type: json headers (backwards-compatible).
+ delete-by-query now targets the 5.x API route (breaking change from 2.x).
 
 Contributed by [Brian T. Rice](https://github.com/briantrice) from [Han Tuzun](https://github.com/hantuzun).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 ## Changes between Elastisch 2.2.x and 3.0.0 (unreleased)
 
-### ElasticSeach 2.3.x Compatibility
+### ElasticSearch 5.x Compatibility
+
+ This is part of ongoing effort to support 5.x.
+ POST calls now include content-type: json headers (backwards-compatible).
+
+Contributed by [Brian T. Rice](https://github.com/briantrice) from [Han Tuzun](https://github.com/hantuzun).
+
+### ElasticSearch 2.3.x Compatibility
 
 This involves removing some features as [Elasticsearch 2.0 has breaking public API changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-2.0.html).
 

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -271,11 +271,11 @@
 
 (defn delete-by-query-url
   ([conn]
-     (url-with-path conn "/_all/_query"))
+     (url-with-path conn "/_all/_delete_by_query"))
   ([conn ^String index-name]
-     (url-with-path conn index-name "_query"))
+     (url-with-path conn index-name "_delete_by_query"))
   ([conn ^String index-name ^String mapping-type]
-     (url-with-path conn index-name mapping-type "_query")))
+     (url-with-path conn index-name mapping-type "_delete_by_query")))
 
 (defn more-like-this-url
   [conn ^String index-name ^String mapping-type]

--- a/src/clojurewerkz/elastisch/rest.clj
+++ b/src/clojurewerkz/elastisch/rest.clj
@@ -61,6 +61,7 @@
         (http/post (merge (.http-opts conn)
                           options
                           {:accept :json
+                           :content-type :json
                            ;:throw-exceptions false ;;ables to see ES when debugging
                            :body (json/encode body)}))
         (:body)

--- a/src/clojurewerkz/elastisch/rest/document.clj
+++ b/src/clojurewerkz/elastisch/rest/document.clj
@@ -335,22 +335,22 @@
   Multiple indexes and types can be specified by passing in a seq of strings,
   otherwise specifying a string suffices."
   ([^Connection conn index mapping-type query]
-     (rest/delete conn
-                  (rest/delete-by-query-url
-                    conn
-                    (join-names index)
-                    (join-names mapping-type))
-                  {:body {:query query}}))
+     (rest/post conn
+                (rest/delete-by-query-url
+                  conn
+                  (join-names index)
+                  (join-names mapping-type))
+                {:body {:query query}}))
   ([^Connection conn index mapping-type query opts]
-     (rest/delete conn
-                  (rest/delete-by-query-url
-                    conn
-                    (join-names index)
-                    (join-names mapping-type))
-                  {:query-params (select-keys opts
-                                              (conj optional-delete-query-parameters
-                                                    :ignore_unavailable))
-                   :body {:query query}})))
+     (rest/post conn
+                (rest/delete-by-query-url
+                  conn
+                  (join-names index)
+                  (join-names mapping-type))
+                {:query-params (select-keys opts
+                                            (conj optional-delete-query-parameters
+                                                  :ignore_unavailable))
+                 :body {:query query}})))
 
 (defn delete-by-query-across-all-types
   "Performs a delete-by-query operation over one or more indexes, across all


### PR DESCRIPTION
This mainly fixes the content-type header so that Elasticsearch 5 does not complain.

Related (high-level) issue: https://github.com/clojurewerkz/elastisch/issues/245

I'm including a cherry-picked change from Han Tuzun for delete-by-query which is not backwards-compatible. Please advise on that; could delay that easily.